### PR TITLE
Add Business -> Tiers navigation and routes

### DIFF
--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -1,1 +1,29 @@
-# Register your receivers here
+from django.dispatch import receiver
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+
+try:
+    from eventyay.control.signals import nav_global
+except ImportError:
+    nav_global = None
+
+
+if nav_global:
+
+    @receiver(nav_global, dispatch_uid="business_tiers_nav")
+    def business_tiers_nav(sender, request, **kwargs):
+        url = request.resolver_match
+        if not url:
+            return []
+
+        return [
+            {
+                "label": _("Tiers"),
+                "url": reverse("eventyay_business:tiers.list"),
+                "active": (
+                    url.namespace == "eventyay_business"
+                    and url.url_name.startswith("tiers.")
+                ),
+                "parent": reverse("eventyay_admin:admin.global.business"),
+            }
+        ]

--- a/eventyay_business/templates/eventyay_business/tiers/list.html
+++ b/eventyay_business/templates/eventyay_business/tiers/list.html
@@ -1,0 +1,11 @@
+{% extends "pretixcontrol/admin/base.html" %}
+{% load i18n %}
+
+{% block title %}
+    {% trans "Tiers" %}
+{% endblock %}
+
+{% block content %}
+    <h1>{% trans "Tiers" %}</h1>
+    <p>{% trans "Tier management coming soon." %}</p>
+{% endblock %}

--- a/eventyay_business/urls.py
+++ b/eventyay_business/urls.py
@@ -1,0 +1,9 @@
+from django.urls import path
+
+from . import views
+
+urlpatterns = [
+    path(
+        "admin/global/business/tiers/", views.TierListView.as_view(), name="tiers.list"
+    ),
+]

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -1,0 +1,6 @@
+from django.views.generic import TemplateView
+from eventyay.control.permissions import AdministratorPermissionRequiredMixin
+
+
+class TierListView(AdministratorPermissionRequiredMixin, TemplateView):
+    template_name = "eventyay_business/tiers/list.html"


### PR DESCRIPTION
Resolves #3. Injects the Tiers navigation item below Business and creates placeholder routes and views.

## Summary by Sourcery

Add Business administration navigation and routing for the upcoming Tiers management page.

New Features:
- Add a Tiers item under the Business administration navigation with active-state highlighting.
- Provide an administrator-only Tiers route and placeholder view.