### PR TITLE
chore: add notify-eventyay workflow

### DIFF
--- a/.github/workflows/notify-eventyay.yml
+++ b/.github/workflows/notify-eventyay.yml
@@ -1,0 +1,35 @@
+name: Notify Eventyay Main Repo
+
+on:
+  push:
+    branches:
+      - main
+      - dev
+
+jobs:
+  dispatch:
+    if: github.repository_owner == 'fossasia'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Warn if token is missing
+        if: env.TOKEN == ''
+        env:
+          TOKEN: ${{ secrets.EVENTYAY_DISPATCH_TOKEN }}
+        run: echo "::warning::EVENTYAY_DISPATCH_TOKEN is not set, skipping repository dispatch"
+
+      - name: Dispatch plugin_updated event
+        if: env.TOKEN != ''
+        env:
+          TOKEN: ${{ secrets.EVENTYAY_DISPATCH_TOKEN }}
+        uses: peter-evans/repository-dispatch@v4
+        with:
+          token: ${{ secrets.EVENTYAY_DISPATCH_TOKEN }}
+          repository: fossasia/eventyay
+          event-type: plugin_updated
+          client-payload: |
+            {
+              "plugin": "${{ github.event.repository.name }}",
+              "repo": "${{ github.repository }}",
+              "branch": "${{ github.ref_name }}",
+              "commit_sha": "${{ github.sha }}"
+            }


### PR DESCRIPTION
This PR adds the notify-eventyay workflow to trigger builds and pin updates on the main eventyay repository when this plugin is updated.

## Summary by Sourcery

CI:
- Add a GitHub Actions workflow that notifies the main Eventyay repository of plugin updates on pushes to the main and dev branches, including commit metadata and safe handling for missing dispatch credentials.