### PR TITLE
feat: add capability registry and builtin catalogue

### DIFF
--- a/eventyay_business/apps.py
+++ b/eventyay_business/apps.py
@@ -31,3 +31,6 @@ class PluginApp(PluginConfig):
 
     def ready(self):
         from . import signals  # NOQA
+        from .capabilities import register_builtin_capabilities
+
+        register_builtin_capabilities()

--- a/eventyay_business/capabilities.py
+++ b/eventyay_business/capabilities.py
@@ -1,0 +1,124 @@
+from dataclasses import dataclass
+from enum import Enum
+
+
+class CapabilityType(Enum):
+    BOOLEAN = "boolean"
+    INTEGER = "integer"
+    DECIMAL = "decimal"
+    MONEY = "money"
+
+
+class CapabilityAlreadyRegistered(ValueError):
+    pass
+
+
+class UnknownCapability(KeyError):
+    pass
+
+
+@dataclass(frozen=True, slots=True)
+class Capability:
+    name: str
+    value_type: CapabilityType
+    unit: str = ""
+
+
+class CapabilityRegistry:
+    def __init__(self) -> None:
+        self._capabilities: dict[str, Capability] = {}
+
+    def register(
+        self,
+        name: str,
+        value_type: CapabilityType,
+        unit: str = "",
+    ) -> Capability:
+        if not name or name != name.strip():
+            raise ValueError("Capability name must be a non-empty identifier.")
+
+        capability = Capability(name=name, value_type=value_type, unit=unit)
+        existing = self._capabilities.get(name)
+        if existing is None:
+            self._capabilities[name] = capability
+            return capability
+        if existing != capability:
+            raise CapabilityAlreadyRegistered(
+                f"Capability {name!r} is already registered as "
+                f"{existing.value_type.value}"
+                + (f" ({existing.unit})" if existing.unit else "")
+                + "."
+            )
+        return existing
+
+    def get(self, name: str) -> Capability:
+        try:
+            return self._capabilities[name]
+        except KeyError as exc:
+            raise UnknownCapability(name) from exc
+
+    def is_registered(self, name: str) -> bool:
+        return name in self._capabilities
+
+    def all(self) -> tuple[Capability, ...]:
+        return tuple(self._capabilities[name] for name in sorted(self._capabilities))
+
+
+registry = CapabilityRegistry()
+
+# Issue #6 catalogue plus the remaining initial capabilities from epic #1.
+BUILTIN_CAPABILITIES: tuple[tuple[str, CapabilityType, str], ...] = (
+    ("video.youtube", CapabilityType.BOOLEAN, ""),
+    ("video.announcements", CapabilityType.BOOLEAN, ""),
+    ("video.chat", CapabilityType.BOOLEAN, ""),
+    ("video.jitsi", CapabilityType.BOOLEAN, ""),
+    ("video.jitsi.concurrent_rooms", CapabilityType.INTEGER, "rooms"),
+    ("video.jitsi.participant_limit", CapabilityType.INTEGER, "participants"),
+    ("video.jitsi.room_hours", CapabilityType.DECIMAL, "hours"),
+    ("video.loungemesh", CapabilityType.BOOLEAN, ""),
+    ("video.loungemesh.spaces", CapabilityType.INTEGER, "spaces"),
+    ("email.bulk.monthly", CapabilityType.INTEGER, "emails"),
+    ("organizer.full_admins", CapabilityType.INTEGER, "seats"),
+    ("api.read", CapabilityType.BOOLEAN, ""),
+    ("api.write", CapabilityType.BOOLEAN, ""),
+    ("api.webhooks", CapabilityType.BOOLEAN, ""),
+    ("commerce.platform_fee_percent", CapabilityType.DECIMAL, "percent"),
+    ("registration.free_allowance_per_event", CapabilityType.INTEGER, "registrations"),
+    ("registration.free_overage_price", CapabilityType.MONEY, ""),
+    ("support.priority", CapabilityType.BOOLEAN, ""),
+)
+
+
+def register_capability(
+    name: str,
+    value_type: CapabilityType,
+    unit: str = "",
+    *,
+    target: CapabilityRegistry | None = None,
+) -> Capability:
+    """Register a capability. Other plugins should call this from AppConfig.ready()."""
+    return (target or registry).register(name, value_type, unit=unit)
+
+
+def get_capability(
+    name: str, *, target: CapabilityRegistry | None = None
+) -> Capability:
+    return (target or registry).get(name)
+
+
+def get_capabilities(
+    *, target: CapabilityRegistry | None = None
+) -> tuple[Capability, ...]:
+    return (target or registry).all()
+
+
+def is_registered(name: str, *, target: CapabilityRegistry | None = None) -> bool:
+    return (target or registry).is_registered(name)
+
+
+def register_builtin_capabilities(
+    target: CapabilityRegistry | None = None,
+) -> None:
+    destination = target or registry
+    for name, value_type, unit in BUILTIN_CAPABILITIES:
+        destination.register(name, value_type, unit=unit)

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -1,0 +1,116 @@
+import pytest
+
+from eventyay_business.capabilities import (
+    BUILTIN_CAPABILITIES,
+    Capability,
+    CapabilityAlreadyRegistered,
+    CapabilityRegistry,
+    CapabilityType,
+    UnknownCapability,
+    get_capabilities,
+    get_capability,
+    is_registered,
+    register_builtin_capabilities,
+    register_capability,
+    registry,
+)
+
+REQUIRED_CAPABILITIES = {
+    "video.youtube": CapabilityType.BOOLEAN,
+    "video.jitsi": CapabilityType.BOOLEAN,
+    "video.jitsi.concurrent_rooms": CapabilityType.INTEGER,
+    "video.loungemesh": CapabilityType.BOOLEAN,
+    "email.bulk.monthly": CapabilityType.INTEGER,
+    "organizer.full_admins": CapabilityType.INTEGER,
+    "api.read": CapabilityType.BOOLEAN,
+    "api.write": CapabilityType.BOOLEAN,
+    "api.webhooks": CapabilityType.BOOLEAN,
+    "commerce.platform_fee_percent": CapabilityType.DECIMAL,
+    "registration.free_allowance_per_event": CapabilityType.INTEGER,
+    "registration.free_overage_price": CapabilityType.MONEY,
+    "support.priority": CapabilityType.BOOLEAN,
+}
+
+
+def test_register_and_get_capability():
+    capabilities = CapabilityRegistry()
+    registered = capabilities.register("video.custom", CapabilityType.BOOLEAN)
+
+    assert registered == Capability("video.custom", CapabilityType.BOOLEAN)
+    assert capabilities.get("video.custom") is registered
+    assert capabilities.is_registered("video.custom")
+    assert not capabilities.is_registered("video.missing")
+
+
+def test_register_is_idempotent_for_the_same_definition():
+    capabilities = CapabilityRegistry()
+    first = capabilities.register("api.write", CapabilityType.BOOLEAN)
+    second = capabilities.register("api.write", CapabilityType.BOOLEAN)
+
+    assert first is second
+
+
+def test_conflicting_registration_is_rejected():
+    capabilities = CapabilityRegistry()
+    capabilities.register("email.bulk.monthly", CapabilityType.INTEGER, unit="emails")
+
+    with pytest.raises(CapabilityAlreadyRegistered, match="email.bulk.monthly"):
+        capabilities.register("email.bulk.monthly", CapabilityType.BOOLEAN)
+
+
+def test_unknown_capability_raises():
+    capabilities = CapabilityRegistry()
+
+    with pytest.raises(UnknownCapability, match="missing.capability"):
+        capabilities.get("missing.capability")
+
+
+def test_empty_capability_name_is_rejected():
+    capabilities = CapabilityRegistry()
+
+    with pytest.raises(ValueError, match="non-empty"):
+        capabilities.register("", CapabilityType.BOOLEAN)
+    with pytest.raises(ValueError, match="non-empty"):
+        capabilities.register("  padded  ", CapabilityType.BOOLEAN)
+
+
+def test_plugin_hook_registers_on_an_isolated_registry():
+    capabilities = CapabilityRegistry()
+
+    register_capability(
+        "plugins.exhibition",
+        CapabilityType.BOOLEAN,
+        target=capabilities,
+    )
+
+    assert capabilities.is_registered("plugins.exhibition")
+    assert not is_registered("plugins.exhibition", target=CapabilityRegistry())
+
+
+def test_builtin_catalogue_includes_required_capabilities():
+    capabilities = CapabilityRegistry()
+    register_builtin_capabilities(capabilities)
+
+    for name, value_type in REQUIRED_CAPABILITIES.items():
+        capability = capabilities.get(name)
+        assert capability.value_type is value_type
+
+    assert {item[0] for item in BUILTIN_CAPABILITIES} >= set(REQUIRED_CAPABILITIES)
+
+
+def test_builtin_registration_is_idempotent():
+    capabilities = CapabilityRegistry()
+    register_builtin_capabilities(capabilities)
+    register_builtin_capabilities(capabilities)
+
+    assert len(capabilities.all()) == len(BUILTIN_CAPABILITIES)
+
+
+def test_module_registry_exposes_helpers():
+    register_builtin_capabilities()
+
+    assert is_registered("api.write")
+    assert get_capability("api.write").value_type is CapabilityType.BOOLEAN
+    names = {capability.name for capability in get_capabilities()}
+    assert names >= set(REQUIRED_CAPABILITIES)
+    assert registry.is_registered("support.priority")


### PR DESCRIPTION
## Summary
- Add a typed capability registry (boolean, integer, decimal, money) that other Eventyay plugins can extend from `AppConfig.ready()`.
- Seed the issue #6 catalogue plus the remaining initial capabilities from epic #1.
- Register the builtins when this plugin starts, and cover register/get, idempotency, and conflicts in tests.

Fixes #6

## Test plan
- [ ] `pytest tests/test_capabilities.py` (or `pytest tests -p no:django` if Eventyay is not installed locally)
- [ ] `black --check .`
- [ ] `isort -c .`
- [ ] `flake8 .`
- [ ] Confirm CI is green

Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Introduce an extensible capability registry and initialise it with the platform’s built-in capability catalogue.

New Features:
- Add an extensible, typed capability registry with support for boolean, integer, decimal, and monetary values.
- Provide a built-in catalogue of video, email, organizer, API, commerce, registration, and support capabilities.
- Automatically register built-in capabilities when the Eventyay plugin starts.

Enhancements:
- Support capability lookup, registration status checks, deterministic enumeration, idempotent registration, and conflict detection.

Tests:
- Add coverage for capability registration, lookup, validation, idempotency, conflicts, built-in catalogue contents, and isolated plugin registration.