### PR TITLE
fix: correct template base path for subscriptions admin

### DIFF
--- a/eventyay_business/templates/eventyay_business/subscriptions/form.html
+++ b/eventyay_business/templates/eventyay_business/subscriptions/form.html
@@ -1,4 +1,4 @@
-{% extends "eventyay_admin/base.html" %}
+{% extends "pretixcontrol/admin/base.html" %}
 {% load i18n %}
 {% load bootstrap3 %}
 

--- a/eventyay_business/templates/eventyay_business/subscriptions/list.html
+++ b/eventyay_business/templates/eventyay_business/subscriptions/list.html
@@ -1,4 +1,4 @@
-{% extends "eventyay_admin/base.html" %}
+{% extends "pretixcontrol/admin/base.html" %}
 {% load i18n %}
 
 {% block title %}{% trans "Subscriptions" %}{% endblock %}


### PR DESCRIPTION
The global admin base template is located at `pretixcontrol/admin/base.html`, not `eventyay_admin/base.html`.

## Summary by Sourcery

Bug Fixes:
- Correct the base template used by the subscriptions form and list pages so the admin views render successfully.