### PR TITLE
feat: Organizer Plan UI and Entitlement Enforcement

### DIFF
--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -7,11 +7,16 @@ try:
 except ImportError:
     nav_global = None
 
+try:
+    from eventyay.base.entitlements import EntitlementDecision
+except ImportError:
+    EntitlementDecision = None
 
 try:
-    from eventyay.base.signals import register_entitlements
+    from eventyay.base.signals import register_entitlements, entitlement_check
 except ImportError:
     register_entitlements = None
+    entitlement_check = None
 
 
 if nav_global:
@@ -87,3 +92,44 @@ def auto_assign_free_tier(sender, instance, created, **kwargs):
         status=SubscriptionStatus.ACTIVE,
         starts_at=now(),
     )
+
+
+if entitlement_check and EntitlementDecision:
+
+    @receiver(entitlement_check, dispatch_uid="business_entitlement_check")
+    def enforce_entitlements(sender, capability: str, event=None, quantity: int = 1, **kwargs):
+        from .capabilities import get_capability, CapabilityValueType
+        from .models import Subscription
+        
+        organizer = sender
+        
+        cap_def = get_capability(capability)
+        if not cap_def:
+            return None
+            
+        sub = Subscription.objects.filter(
+            organizer=organizer, 
+            status__in=["active", "pending"]
+        ).select_related("tier_version").first()
+        
+        value = None
+        if sub and sub.tier_version:
+            ent = sub.tier_version.entitlements.filter(capability=capability).first()
+            if ent:
+                value = ent.get_typed_value()
+                
+        if value is None:
+            value = cap_def.default_value
+            
+        if cap_def.value_type == CapabilityValueType.BOOLEAN:
+            if value:
+                return EntitlementDecision(allowed=True)
+            else:
+                return EntitlementDecision(allowed=False, reason_code="tier_restriction", message="This feature is not available on your current plan.")
+                
+        if cap_def.value_type == CapabilityValueType.INTEGER:
+            if value is not None and quantity > value:
+                return EntitlementDecision(allowed=False, reason_code="tier_limit_exceeded", limit=value, message="You have reached the maximum limit for this feature on your current plan.")
+            return EntitlementDecision(allowed=True, limit=value)
+            
+        return EntitlementDecision(allowed=True)

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -108,9 +108,14 @@ if entitlement_check and EntitlementDecision:
         if not cap_def:
             return None
             
+        from django.utils.timezone import now
+        current_time = now()
         sub = Subscription.objects.filter(
-            organizer=organizer, 
-            status__in=["active", "pending"]
+            organizer=organizer,
+            status="active",
+            starts_at__lte=current_time,
+        ).exclude(
+            ends_at__lt=current_time
         ).select_related("tier_version").first()
         
         value = None

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -3,9 +3,10 @@ from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 
 try:
-    from eventyay.control.signals import nav_global
+    from eventyay.control.signals import nav_global, nav_organizer
 except ImportError:
     nav_global = None
+    nav_organizer = None
 
 try:
     from eventyay.base.entitlements import EntitlementDecision
@@ -133,3 +134,27 @@ if entitlement_check and EntitlementDecision:
             return EntitlementDecision(allowed=True, limit=value)
             
         return EntitlementDecision(allowed=True)
+
+
+if nav_organizer:
+    @receiver(nav_organizer, dispatch_uid="business_organizer_plan_nav")
+    def business_organizer_plan_nav(sender, request, organizer, **kwargs):
+        url = request.resolver_match
+        if not url:
+            return []
+
+        return [
+            {
+                "label": _("Plan & Billing"),
+                "url": reverse(
+                    "plugins:eventyay_business:organizer.plan",
+                    kwargs={"organizer": organizer.slug},
+                ),
+                "active": (
+                    url.namespace == "plugins:eventyay_business"
+                    and url.url_name == "organizer.plan"
+                ),
+                "icon": "credit-card",
+                "position": 100,
+            }
+        ]

--- a/eventyay_business/templates/eventyay_business/organizer/plan.html
+++ b/eventyay_business/templates/eventyay_business/organizer/plan.html
@@ -1,0 +1,80 @@
+{% extends "pretixcontrol/organizers/base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Plan & Usage" %}{% endblock %}
+
+{% block inner %}
+    <h1>{% trans "Plan & Usage" %}</h1>
+    
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% trans "Current Subscription" %}</h3>
+        </div>
+        <div class="panel-body">
+            {% if subscription %}
+                <p>
+                    <strong>{% trans "Tier:" %}</strong> {{ subscription.tier_version.tier.name }} (v{{ subscription.tier_version.version }})<br>
+                    <strong>{% trans "Status:" %}</strong> {{ subscription.get_status_display }}<br>
+                    <strong>{% trans "Started:" %}</strong> {{ subscription.starts_at|date:"SHORT_DATE_FORMAT" }}
+                </p>
+                <p class="text-muted">
+                    {{ subscription.tier_version.tier.description }}
+                </p>
+            {% else %}
+                <div class="alert alert-warning">
+                    {% trans "No active subscription found. You are currently operating without an assigned plan." %}
+                </div>
+            {% endif %}
+        </div>
+    </div>
+    
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">{% trans "Your Capabilities & Limits" %}</h3>
+        </div>
+        <table class="table table-striped">
+            <thead>
+                <tr>
+                    <th>{% trans "Category" %}</th>
+                    <th>{% trans "Feature" %}</th>
+                    <th>{% trans "Limit / Access" %}</th>
+                    <th>{% trans "Type" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for item in effective_entitlements %}
+                    <tr>
+                        <td>{{ item.capability.category }}</td>
+                        <td>
+                            <strong>{{ item.capability.label }}</strong>
+                            <div class="help-block text-muted" style="margin: 0; font-size: 12px;">
+                                {{ item.capability.description }}
+                            </div>
+                        </td>
+                        <td>
+                            {% if item.capability.value_type == "boolean" %}
+                                {% if item.effective_value %}
+                                    <span class="label label-success">{% trans "Enabled" %}</span>
+                                {% else %}
+                                    <span class="label label-danger">{% trans "Disabled" %}</span>
+                                {% endif %}
+                            {% else %}
+                                <strong>{{ item.effective_value }}</strong>
+                                {% if item.capability.unit %} {{ item.capability.unit }}{% endif %}
+                            {% endif %}
+                            
+                            {% if item.is_overridden %}
+                                <span class="label label-info" title="Custom limit set for this tier" style="margin-left: 5px;">Custom</span>
+                            {% endif %}
+                        </td>
+                        <td><code>{{ item.capability.name }}</code></td>
+                    </tr>
+                {% empty %}
+                    <tr>
+                        <td colspan="4">{% trans "No capabilities defined in the system." %}</td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+{% endblock %}

--- a/eventyay_business/urls.py
+++ b/eventyay_business/urls.py
@@ -3,6 +3,7 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
+    # Global Admin URLs
     path("admin/global/business/tiers/", views.TierListView.as_view(), name="tiers.list"),
     path("admin/global/business/tiers/create/", views.TierCreateView.as_view(), name="tiers.create"),
     path("admin/global/business/tiers/<int:pk>/", views.TierDetailView.as_view(), name="tiers.detail"),
@@ -14,4 +15,7 @@ urlpatterns = [
     path("admin/global/business/subscriptions/", views.SubscriptionListView.as_view(), name="subscriptions.list"),
     path("admin/global/business/subscriptions/create/", views.SubscriptionCreateView.as_view(), name="subscriptions.create"),
     path("admin/global/business/subscriptions/<int:pk>/edit/", views.SubscriptionUpdateView.as_view(), name="subscriptions.edit"),
+    
+    # Organizer URLs
+    path("control/organizer/<str:organizer>/business/plan/", views.OrganizerPlanView.as_view(), name="organizer.plan"),
 ]

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -204,3 +204,44 @@ class SubscriptionUpdateView(AdministratorPermissionRequiredMixin, UpdateView):
     def get_success_url(self):
         messages.success(self.request, _("Subscription updated successfully."))
         return reverse("plugins:eventyay_business:subscriptions.list")
+
+from eventyay.control.permissions import OrganizerPermissionRequiredMixin
+from eventyay.control.views.organizer_views.organizer_detail_view_mixin import OrganizerDetailViewMixin
+from django.views.generic import TemplateView
+from .capabilities import get_all_capabilities
+
+class OrganizerPlanView(OrganizerPermissionRequiredMixin, OrganizerDetailViewMixin, TemplateView):
+    permission = "can_change_organizer_settings"
+    template_name = "eventyay_business/organizer/plan.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        organizer = self.request.organizer
+        from .models import Subscription
+        
+        sub = Subscription.objects.filter(
+            organizer=organizer, 
+            status__in=['active', 'pending']
+        ).select_related('tier_version__tier').first()
+        
+        ctx['subscription'] = sub
+        
+        # Build a complete picture of effective entitlements
+        effective_entitlements = []
+        all_caps = get_all_capabilities()
+        
+        override_dict = {}
+        if sub and sub.tier_version:
+            for ent in sub.tier_version.entitlements.all():
+                override_dict[ent.capability] = ent.get_typed_value()
+                
+        for cap in all_caps:
+            val = override_dict.get(cap.name, cap.default_value)
+            effective_entitlements.append({
+                'capability': cap,
+                'effective_value': val,
+                'is_overridden': cap.name in override_dict
+            })
+            
+        ctx['effective_entitlements'] = sorted(effective_entitlements, key=lambda x: x['capability'].category)
+        return ctx

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -219,9 +219,14 @@ class OrganizerPlanView(OrganizerPermissionRequiredMixin, OrganizerDetailViewMix
         organizer = self.request.organizer
         from .models import Subscription
         
+        from django.utils.timezone import now
+        current_time = now()
         sub = Subscription.objects.filter(
-            organizer=organizer, 
-            status__in=['active', 'pending']
+            organizer=organizer,
+            status="active",
+            starts_at__lte=current_time,
+        ).exclude(
+            ends_at__lt=current_time
         ).select_related('tier_version__tier').first()
         
         ctx['subscription'] = sub

--- a/tests/test_entitlement_receiver.py
+++ b/tests/test_entitlement_receiver.py
@@ -15,12 +15,9 @@ def dummy_organizer():
 def business_setup(dummy_organizer):
     tier = Tier.objects.create(slug="pro", name="Pro", is_public=True)
     version = TierVersion.objects.create(tier=tier, version=1, published_at=now())
-    sub = Subscription.objects.create(
-        organizer=dummy_organizer,
-        tier_version=version,
-        status='active',
-        starts_at=now()
-    )
+    sub = Subscription.objects.get(organizer=dummy_organizer)
+    sub.tier_version = version
+    sub.save(update_fields=["tier_version"])
     
     # Register a test capability
     cap = Capability(

--- a/tests/test_entitlement_receiver.py
+++ b/tests/test_entitlement_receiver.py
@@ -1,0 +1,83 @@
+import pytest
+from django.utils.timezone import now
+from unittest.mock import MagicMock
+
+from eventyay.base.models import Organizer
+from eventyay.base.entitlements import EntitlementDecision, check_entitlement
+from eventyay_business.models import Subscription, Tier, TierVersion, TierEntitlement
+from eventyay_business.capabilities import Capability, CapabilityValueType, register_capability
+
+@pytest.fixture
+def dummy_organizer():
+    return Organizer.objects.create(name="Test Organizer", slug="test-org")
+
+@pytest.fixture
+def business_setup(dummy_organizer):
+    tier = Tier.objects.create(slug="pro", name="Pro", is_public=True)
+    version = TierVersion.objects.create(tier=tier, version=1, published_at=now())
+    sub = Subscription.objects.create(
+        organizer=dummy_organizer,
+        tier_version=version,
+        status='active',
+        starts_at=now()
+    )
+    
+    # Register a test capability
+    cap = Capability(
+        name="test.bool",
+        label="Test Boolean",
+        value_type=CapabilityValueType.BOOLEAN,
+        default_value=False
+    )
+    register_capability(cap, override=True)
+    
+    cap_int = Capability(
+        name="test.int",
+        label="Test Integer",
+        value_type=CapabilityValueType.INTEGER,
+        default_value=10
+    )
+    register_capability(cap_int, override=True)
+    
+    return tier, version, sub
+
+@pytest.mark.django_db
+def test_receiver_boolean_default_deny(dummy_organizer, business_setup):
+    """If no override exists, it should fall back to the False default and deny."""
+    decision = check_entitlement(dummy_organizer, capability="test.bool")
+    assert decision.allowed is False
+    assert decision.reason_code == "tier_restriction"
+
+@pytest.mark.django_db
+def test_receiver_boolean_explicit_allow(dummy_organizer, business_setup):
+    """If an explicit override exists, it should use it."""
+    tier, version, sub = business_setup
+    TierEntitlement.objects.create(tier_version=version, capability="test.bool", value="true")
+    
+    decision = check_entitlement(dummy_organizer, capability="test.bool")
+    assert decision.allowed is True
+
+@pytest.mark.django_db
+def test_receiver_integer_default_allow(dummy_organizer, business_setup):
+    """If quantity <= default_value, it should allow."""
+    decision = check_entitlement(dummy_organizer, capability="test.int", quantity=5)
+    assert decision.allowed is True
+    assert decision.limit == 10
+
+@pytest.mark.django_db
+def test_receiver_integer_default_deny(dummy_organizer, business_setup):
+    """If quantity > default_value, it should deny."""
+    decision = check_entitlement(dummy_organizer, capability="test.int", quantity=15)
+    assert decision.allowed is False
+    assert decision.reason_code == "tier_limit_exceeded"
+    assert decision.limit == 10
+
+@pytest.mark.django_db
+def test_receiver_integer_explicit_override(dummy_organizer, business_setup):
+    """Explicit override changes the limit."""
+    tier, version, sub = business_setup
+    TierEntitlement.objects.create(tier_version=version, capability="test.int", value="20")
+    
+    decision = check_entitlement(dummy_organizer, capability="test.int", quantity=15)
+    assert decision.allowed is True
+    assert decision.limit == 20


### PR DESCRIPTION
Fixes #10, Fixes #15, Fixes #16

<img width="4608" height="2848" alt="image" src="https://github.com/user-attachments/assets/cf448fff-b94c-4702-8c60-ddc52f8ef310" />


This is a comprehensive PR that finalizes the freemium gating system.

1. **Organizer Plan UI (Issue #10)**: Adds a new 'Plan & Billing' tab to the Organizer dashboard. Shows the active subscription tier and clearly lists all enabled features and limits (calculating fallbacks automatically).
2. **Write API & Webhooks Enforcement (Issue #15)**: Implements the `entitlement_check` receiver to read the organizer's boolean capabilities (e.g., `api.write`) and block them if they aren't on a paid tier.
3. **Integer Limit Enforcement (Issue #16)**: The same receiver dynamically handles integer limits (e.g., Jitsi concurrent rooms, Max Events) by checking if the requested quantity exceeds their effective tier limit.

## Summary by Sourcery

Provide organizer plan visibility and enforce subscription entitlements across gated features.

New Features:
- Add an organizer-facing Plan & Usage page showing the active subscription and effective capability access and limits.

Bug Fixes:
- Enforce boolean feature access and integer usage limits through entitlement checks, including fallback defaults and tier-specific overrides.

Tests:
- Add coverage for default and overridden boolean and integer entitlement decisions.