### PR TITLE
fix: resolve CI failures for formatting and tests

### DIFF
--- a/eventyay_business/__init__.py
+++ b/eventyay_business/__init__.py
@@ -1,3 +1,3 @@
 __version__ = "1.0.0"
 
-from .apps import PluginApp
+from .apps import PluginApp  # noqa

--- a/eventyay_business/capabilities.py
+++ b/eventyay_business/capabilities.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
-from enum import Enum
 from typing import Any
 
+from dataclasses import dataclass, field
 from django.utils.translation import gettext_lazy as _
+from enum import Enum
 
 
 class CapabilityValueType(str, Enum):
@@ -67,7 +67,9 @@ class CapabilityRegistry:
             raise ValueError(f"Capability '{capability.name}' is already registered.")
         self._capabilities[capability.name] = capability
 
-    def register_all(self, capabilities: list[Capability], override: bool = False) -> None:
+    def register_all(
+        self, capabilities: list[Capability], override: bool = False
+    ) -> None:
         for cap in capabilities:
             self.register(cap, override=override)
 
@@ -90,7 +92,10 @@ class CapabilityRegistry:
         """
         Returns choices suitable for Django form fields grouped by category or sorted by name.
         """
-        return [(cap.name, f"{cap.name} ({cap.label})") for cap in sorted(self._capabilities.values(), key=lambda c: c.name)]
+        return [
+            (cap.name, f"{cap.name} ({cap.label})")
+            for cap in sorted(self._capabilities.values(), key=lambda c: c.name)
+        ]
 
     def as_dict(self) -> dict[str, dict[str, Any]]:
         """
@@ -139,7 +144,9 @@ STANDARD_CAPABILITIES = [
     Capability(
         name="email.bulk.monthly",
         label=_("Monthly Bulk Emails"),
-        description=_("Monthly allowance of organizer-initiated bulk announcement emails"),
+        description=_(
+            "Monthly allowance of organizer-initiated bulk announcement emails"
+        ),
         value_type=CapabilityValueType.INTEGER,
         category="Email",
         unit="emails",
@@ -149,7 +156,9 @@ STANDARD_CAPABILITIES = [
     Capability(
         name="organizer.full_admins",
         label=_("Full Administrator Seats"),
-        description=_("Maximum number of full team administrators allowed for the organizer"),
+        description=_(
+            "Maximum number of full team administrators allowed for the organizer"
+        ),
         value_type=CapabilityValueType.INTEGER,
         category="Organization",
         unit="admins",
@@ -203,7 +212,9 @@ STANDARD_CAPABILITIES = [
     Capability(
         name="registration.free_overage_price",
         label=_("Free Registration Overage Price"),
-        description=_("Price charged per free registration exceeding the included allowance"),
+        description=_(
+            "Price charged per free registration exceeding the included allowance"
+        ),
         value_type=CapabilityValueType.MONEY,
         category="Registration",
         unit="per registration",
@@ -213,7 +224,9 @@ STANDARD_CAPABILITIES = [
     Capability(
         name="support.priority",
         label=_("Priority Support"),
-        description=_("Access to dedicated priority support and expedited SLA response"),
+        description=_(
+            "Access to dedicated priority support and expedited SLA response"
+        ),
         value_type=CapabilityValueType.BOOLEAN,
         category="Support",
         default_value=False,

--- a/eventyay_business/forms.py
+++ b/eventyay_business/forms.py
@@ -3,7 +3,14 @@ from django.forms import inlineformset_factory
 from django.utils.translation import gettext_lazy as _
 
 from .capabilities import get_capability_choices
-from .models import Subscription, SubscriptionStatus, Tier, TierEntitlement, TierPrice, TierVersion
+from .models import (
+    Subscription,
+    SubscriptionStatus,
+    Tier,
+    TierEntitlement,
+    TierPrice,
+    TierVersion,
+)
 
 
 class TierForm(forms.ModelForm):
@@ -60,7 +67,10 @@ class TierEntitlementForm(forms.ModelForm):
                                 _("Value must be a valid whole number (integer).")
                             ),
                         )
-                elif cap.value_type in (CapabilityValueType.DECIMAL, CapabilityValueType.MONEY):
+                elif cap.value_type in (
+                    CapabilityValueType.DECIMAL,
+                    CapabilityValueType.MONEY,
+                ):
                     from decimal import Decimal, InvalidOperation
 
                     try:
@@ -100,10 +110,19 @@ TierEntitlementFormSet = inlineformset_factory(
     TierVersion,
     TierEntitlement,
     form=TierEntitlementForm,
-    fields=["capability", "value", "unit", "overage_allowed", "overage_price", "currency", "overage_block_size"],
+    fields=[
+        "capability",
+        "value",
+        "unit",
+        "overage_allowed",
+        "overage_price",
+        "currency",
+        "overage_block_size",
+    ],
     extra=1,
     can_delete=True,
 )
+
 
 class SubscriptionAdminForm(forms.ModelForm):
     class Meta:
@@ -126,13 +145,17 @@ class SubscriptionAdminForm(forms.ModelForm):
         organizer = cleaned_data.get("organizer")
         status = cleaned_data.get("status")
 
-        if organizer and status in [SubscriptionStatus.ACTIVE, SubscriptionStatus.PENDING]:
+        if organizer and status in [
+            SubscriptionStatus.ACTIVE,
+            SubscriptionStatus.PENDING,
+        ]:
             qs = Subscription.objects.filter(
-                organizer=organizer, status__in=[SubscriptionStatus.ACTIVE, SubscriptionStatus.PENDING]
+                organizer=organizer,
+                status__in=[SubscriptionStatus.ACTIVE, SubscriptionStatus.PENDING],
             )
             if self.instance and self.instance.pk:
                 qs = qs.exclude(pk=self.instance.pk)
-            
+
             if qs.exists():
                 raise forms.ValidationError(
                     _("This organizer already has an active or pending subscription.")

--- a/eventyay_business/migrations/0002_tierentitlement_currency.py
+++ b/eventyay_business/migrations/0002_tierentitlement_currency.py
@@ -6,13 +6,15 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('eventyay_business', '0001_initial'),
+        ("eventyay_business", "0001_initial"),
     ]
 
     operations = [
         migrations.AddField(
-            model_name='tierentitlement',
-            name='currency',
-            field=models.CharField(blank=True, max_length=3, null=True, verbose_name='Overage currency'),
+            model_name="tierentitlement",
+            name="currency",
+            field=models.CharField(
+                blank=True, max_length=3, null=True, verbose_name="Overage currency"
+            ),
         ),
     ]

--- a/eventyay_business/migrations/0003_alter_tierentitlement_value.py
+++ b/eventyay_business/migrations/0003_alter_tierentitlement_value.py
@@ -6,13 +6,15 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('eventyay_business', '0002_tierentitlement_currency'),
+        ("eventyay_business", "0002_tierentitlement_currency"),
     ]
 
     operations = [
         migrations.AlterField(
-            model_name='tierentitlement',
-            name='value',
-            field=models.CharField(blank=True, max_length=100, null=True, verbose_name='Value'),
+            model_name="tierentitlement",
+            name="value",
+            field=models.CharField(
+                blank=True, max_length=100, null=True, verbose_name="Value"
+            ),
         ),
     ]

--- a/eventyay_business/migrations/0004_subscription.py
+++ b/eventyay_business/migrations/0004_subscription.py
@@ -7,33 +7,126 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('eventyay_business', '0003_alter_tierentitlement_value'),
+        ("eventyay_business", "0003_alter_tierentitlement_value"),
     ]
 
     operations = [
         migrations.CreateModel(
-            name='Subscription',
+            name="Subscription",
             fields=[
-                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
-                ('status', models.CharField(choices=[('pending', 'Pending'), ('active', 'Active'), ('past_due', 'Past due'), ('canceled', 'Canceled'), ('expired', 'Expired')], default='pending', max_length=20, verbose_name='Status')),
-                ('billing_interval', models.CharField(blank=True, choices=[('monthly', 'Monthly'), ('annual', 'Annual')], max_length=20, null=True, verbose_name='Billing interval')),
-                ('currency', models.CharField(blank=True, max_length=3, null=True, verbose_name='Currency')),
-                ('starts_at', models.DateTimeField(verbose_name='Starts at')),
-                ('ends_at', models.DateTimeField(blank=True, null=True, verbose_name='Ends at')),
-                ('cancel_at', models.DateTimeField(blank=True, null=True, verbose_name='Cancel at')),
-                ('stripe_customer_id', models.CharField(blank=True, max_length=255, null=True, verbose_name='Stripe customer ID')),
-                ('stripe_subscription_id', models.CharField(blank=True, max_length=255, null=True, verbose_name='Stripe subscription ID')),
-                ('configuration_snapshot', models.JSONField(blank=True, default=dict, verbose_name='Configuration snapshot')),
-                ('created_at', models.DateTimeField(auto_now_add=True, verbose_name='Created at')),
-                ('updated_at', models.DateTimeField(auto_now=True, verbose_name='Updated at')),
-                ('organizer', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='subscriptions', to='base.organizer', verbose_name='Organizer')),
-                ('tier_version', models.ForeignKey(on_delete=django.db.models.deletion.RESTRICT, related_name='subscriptions', to='eventyay_business.tierversion', verbose_name='Tier version')),
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("pending", "Pending"),
+                            ("active", "Active"),
+                            ("past_due", "Past due"),
+                            ("canceled", "Canceled"),
+                            ("expired", "Expired"),
+                        ],
+                        default="pending",
+                        max_length=20,
+                        verbose_name="Status",
+                    ),
+                ),
+                (
+                    "billing_interval",
+                    models.CharField(
+                        blank=True,
+                        choices=[("monthly", "Monthly"), ("annual", "Annual")],
+                        max_length=20,
+                        null=True,
+                        verbose_name="Billing interval",
+                    ),
+                ),
+                (
+                    "currency",
+                    models.CharField(
+                        blank=True, max_length=3, null=True, verbose_name="Currency"
+                    ),
+                ),
+                ("starts_at", models.DateTimeField(verbose_name="Starts at")),
+                (
+                    "ends_at",
+                    models.DateTimeField(blank=True, null=True, verbose_name="Ends at"),
+                ),
+                (
+                    "cancel_at",
+                    models.DateTimeField(
+                        blank=True, null=True, verbose_name="Cancel at"
+                    ),
+                ),
+                (
+                    "stripe_customer_id",
+                    models.CharField(
+                        blank=True,
+                        max_length=255,
+                        null=True,
+                        verbose_name="Stripe customer ID",
+                    ),
+                ),
+                (
+                    "stripe_subscription_id",
+                    models.CharField(
+                        blank=True,
+                        max_length=255,
+                        null=True,
+                        verbose_name="Stripe subscription ID",
+                    ),
+                ),
+                (
+                    "configuration_snapshot",
+                    models.JSONField(
+                        blank=True, default=dict, verbose_name="Configuration snapshot"
+                    ),
+                ),
+                (
+                    "created_at",
+                    models.DateTimeField(auto_now_add=True, verbose_name="Created at"),
+                ),
+                (
+                    "updated_at",
+                    models.DateTimeField(auto_now=True, verbose_name="Updated at"),
+                ),
+                (
+                    "organizer",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="subscriptions",
+                        to="base.organizer",
+                        verbose_name="Organizer",
+                    ),
+                ),
+                (
+                    "tier_version",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.RESTRICT,
+                        related_name="subscriptions",
+                        to="eventyay_business.tierversion",
+                        verbose_name="Tier version",
+                    ),
+                ),
             ],
             options={
-                'verbose_name': 'Subscription',
-                'verbose_name_plural': 'Subscriptions',
-                'ordering': ['-starts_at', '-id'],
-                'constraints': [models.UniqueConstraint(condition=models.Q(('status__in', ['active', 'pending'])), fields=('organizer',), name='unique_active_subscription_per_organizer')],
+                "verbose_name": "Subscription",
+                "verbose_name_plural": "Subscriptions",
+                "ordering": ["-starts_at", "-id"],
+                "constraints": [
+                    models.UniqueConstraint(
+                        condition=models.Q(("status__in", ["active", "pending"])),
+                        fields=("organizer",),
+                        name="unique_active_subscription_per_organizer",
+                    )
+                ],
             },
         ),
     ]

--- a/eventyay_business/migrations/0005_auto_assign_free_tier.py
+++ b/eventyay_business/migrations/0005_auto_assign_free_tier.py
@@ -1,11 +1,12 @@
 from django.db import migrations
 from django.utils.timezone import now
 
+
 def auto_assign_free_tier(apps, schema_editor):
-    Organizer = apps.get_model('base', 'Organizer')
-    Tier = apps.get_model('eventyay_business', 'Tier')
-    TierVersion = apps.get_model('eventyay_business', 'TierVersion')
-    Subscription = apps.get_model('eventyay_business', 'Subscription')
+    Organizer = apps.get_model("base", "Organizer")
+    Tier = apps.get_model("eventyay_business", "Tier")
+    TierVersion = apps.get_model("eventyay_business", "TierVersion")
+    Subscription = apps.get_model("eventyay_business", "Subscription")
 
     # Fetch or create free tier
     free_tier, _ = Tier.objects.get_or_create(
@@ -14,44 +15,51 @@ def auto_assign_free_tier(apps, schema_editor):
             "name": "Free",
             "description": "Default free tier",
             "is_public": True,
-        }
+        },
     )
 
-    latest_version = free_tier.versions.filter(published_at__isnull=False).order_by("-version").first()
+    latest_version = (
+        free_tier.versions.filter(published_at__isnull=False)
+        .order_by("-version")
+        .first()
+    )
     if not latest_version:
         latest_version, _ = TierVersion.objects.get_or_create(
-            tier=free_tier,
-            version=1,
-            defaults={"published_at": now()}
+            tier=free_tier, version=1, defaults={"published_at": now()}
         )
         if latest_version.published_at is None:
             latest_version.published_at = now()
             latest_version.save(update_fields=["published_at"])
 
     # Cross-app relations might not be available on historical models, so query IDs
-    subscribed_org_ids = Subscription.objects.filter(status__in=['active', 'pending']).values_list('organizer_id', flat=True)
+    subscribed_org_ids = Subscription.objects.filter(
+        status__in=["active", "pending"]
+    ).values_list("organizer_id", flat=True)
     organizers_without_subs = Organizer.objects.exclude(pk__in=subscribed_org_ids)
-    
+
     subscriptions_to_create = []
     for org in organizers_without_subs:
         subscriptions_to_create.append(
             Subscription(
                 organizer=org,
                 tier_version=latest_version,
-                status='active',
+                status="active",
                 starts_at=now(),
             )
         )
-    
+
     if subscriptions_to_create:
         Subscription.objects.bulk_create(subscriptions_to_create)
 
+
 class Migration(migrations.Migration):
     dependencies = [
-        ('eventyay_business', '0004_subscription'),
-        ('base', '0001_initial'),  # Ensure base app is loaded
+        ("eventyay_business", "0004_subscription"),
+        ("base", "0001_initial"),  # Ensure base app is loaded
     ]
 
     operations = [
-        migrations.RunPython(auto_assign_free_tier, reverse_code=migrations.RunPython.noop),
+        migrations.RunPython(
+            auto_assign_free_tier, reverse_code=migrations.RunPython.noop
+        ),
     ]

--- a/eventyay_business/models.py
+++ b/eventyay_business/models.py
@@ -68,7 +68,9 @@ class TierVersion(models.Model):
         constraints = [
             models.CheckConstraint(
                 name="tierversion_effective_dates",
-                condition=models.Q(effective_until__isnull=True) | models.Q(effective_from__isnull=True) | models.Q(effective_until__gt=models.F("effective_from")),
+                condition=models.Q(effective_until__isnull=True)
+                | models.Q(effective_from__isnull=True)
+                | models.Q(effective_until__gt=models.F("effective_from")),
             )
         ]
 
@@ -89,7 +91,9 @@ class TierPrice(models.Model):
         verbose_name=_("Tier version"),
     )
     billing_interval = models.CharField(
-        max_length=20, choices=BillingInterval.choices, verbose_name=_("Billing interval")
+        max_length=20,
+        choices=BillingInterval.choices,
+        verbose_name=_("Billing interval"),
     )
     currency = models.CharField(max_length=3, verbose_name=_("Currency"))
     amount = models.DecimalField(
@@ -121,13 +125,19 @@ class TierEntitlement(models.Model):
         verbose_name=_("Tier version"),
     )
     capability = models.CharField(max_length=100, verbose_name=_("Capability"))
-    value = models.CharField(max_length=100, null=True, blank=True, verbose_name=_("Value"))
+    value = models.CharField(
+        max_length=100, null=True, blank=True, verbose_name=_("Value")
+    )
     unit = models.CharField(max_length=50, blank=True, verbose_name=_("Unit"))
     overage_allowed = models.BooleanField(
         default=False, verbose_name=_("Overage allowed")
     )
     overage_price = models.DecimalField(
-        max_digits=10, decimal_places=2, null=True, blank=True, verbose_name=_("Overage price")
+        max_digits=10,
+        decimal_places=2,
+        null=True,
+        blank=True,
+        verbose_name=_("Overage price"),
     )
     currency = models.CharField(
         max_length=3, blank=True, null=True, verbose_name=_("Overage currency")
@@ -165,13 +175,16 @@ class TierEntitlement(models.Model):
         constraints = [
             models.CheckConstraint(
                 name="tierentitlement_overage_price_nonnegative",
-                condition=models.Q(overage_price__isnull=True) | models.Q(overage_price__gte=0),
+                condition=models.Q(overage_price__isnull=True)
+                | models.Q(overage_price__gte=0),
             ),
             models.CheckConstraint(
                 name="tierentitlement_overage_block_positive",
-                condition=models.Q(overage_block_size__isnull=True) | models.Q(overage_block_size__gt=0),
-            )
+                condition=models.Q(overage_block_size__isnull=True)
+                | models.Q(overage_block_size__gt=0),
+            ),
         ]
+
 
 class SubscriptionStatus(models.TextChoices):
     PENDING = "pending", _("Pending")

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -14,7 +14,7 @@ except ImportError:
     EntitlementDecision = None
 
 try:
-    from eventyay.base.signals import register_entitlements, entitlement_check
+    from eventyay.base.signals import entitlement_check, register_entitlements
 except ImportError:
     register_entitlements = None
     entitlement_check = None
@@ -58,6 +58,7 @@ if register_entitlements:
 
         return default_registry.as_dict()
 
+
 from django.db.models.signals import post_save
 from django.utils.timezone import now
 from eventyay.base.models import Organizer
@@ -76,17 +77,19 @@ def auto_assign_free_tier(sender, instance, created, **kwargs):
             "name": "Free",
             "description": "Default free tier",
             "is_public": True,
-        }
+        },
     )
-    
-    latest_version = free_tier.versions.filter(published_at__isnull=False).order_by("-version").first()
+
+    latest_version = (
+        free_tier.versions.filter(published_at__isnull=False)
+        .order_by("-version")
+        .first()
+    )
     if not latest_version:
         latest_version, _ = TierVersion.objects.get_or_create(
-            tier=free_tier,
-            version=1,
-            defaults={"published_at": now()}
+            tier=free_tier, version=1, defaults={"published_at": now()}
         )
-    
+
     Subscription.objects.create(
         organizer=instance,
         tier_version=latest_version,
@@ -98,50 +101,66 @@ def auto_assign_free_tier(sender, instance, created, **kwargs):
 if entitlement_check and EntitlementDecision:
 
     @receiver(entitlement_check, dispatch_uid="business_entitlement_check")
-    def enforce_entitlements(sender, capability: str, event=None, quantity: int = 1, **kwargs):
-        from .capabilities import get_capability, CapabilityValueType
+    def enforce_entitlements(
+        sender, capability: str, event=None, quantity: int = 1, **kwargs
+    ):
+        from .capabilities import CapabilityValueType, get_capability
         from .models import Subscription
-        
+
         organizer = sender
-        
+
         cap_def = get_capability(capability)
         if not cap_def:
             return None
-            
+
         from django.utils.timezone import now
+
         current_time = now()
-        sub = Subscription.objects.filter(
-            organizer=organizer,
-            status="active",
-            starts_at__lte=current_time,
-        ).exclude(
-            ends_at__lt=current_time
-        ).select_related("tier_version").first()
-        
+        sub = (
+            Subscription.objects.filter(
+                organizer=organizer,
+                status="active",
+                starts_at__lte=current_time,
+            )
+            .exclude(ends_at__lt=current_time)
+            .select_related("tier_version")
+            .first()
+        )
+
         value = None
         if sub and sub.tier_version:
             ent = sub.tier_version.entitlements.filter(capability=capability).first()
             if ent:
                 value = ent.get_typed_value()
-                
+
         if value is None:
             value = cap_def.default_value
-            
+
         if cap_def.value_type == CapabilityValueType.BOOLEAN:
             if value:
                 return EntitlementDecision(allowed=True)
             else:
-                return EntitlementDecision(allowed=False, reason_code="tier_restriction", message="This feature is not available on your current plan.")
-                
+                return EntitlementDecision(
+                    allowed=False,
+                    reason_code="tier_restriction",
+                    message="This feature is not available on your current plan.",
+                )
+
         if cap_def.value_type == CapabilityValueType.INTEGER:
             if value is not None and quantity > value:
-                return EntitlementDecision(allowed=False, reason_code="tier_limit_exceeded", limit=value, message="You have reached the maximum limit for this feature on your current plan.")
+                return EntitlementDecision(
+                    allowed=False,
+                    reason_code="tier_limit_exceeded",
+                    limit=value,
+                    message="You have reached the maximum limit for this feature on your current plan.",
+                )
             return EntitlementDecision(allowed=True, limit=value)
-            
+
         return EntitlementDecision(allowed=True)
 
 
 if nav_organizer:
+
     @receiver(nav_organizer, dispatch_uid="business_organizer_plan_nav")
     def business_organizer_plan_nav(sender, request, organizer, **kwargs):
         url = request.resolver_match

--- a/eventyay_business/urls.py
+++ b/eventyay_business/urls.py
@@ -4,18 +4,58 @@ from . import views
 
 urlpatterns = [
     # Global Admin URLs
-    path("admin/global/business/tiers/", views.TierListView.as_view(), name="tiers.list"),
-    path("admin/global/business/tiers/create/", views.TierCreateView.as_view(), name="tiers.create"),
-    path("admin/global/business/tiers/<int:pk>/", views.TierDetailView.as_view(), name="tiers.detail"),
-    path("admin/global/business/tiers/<int:pk>/edit/", views.TierUpdateView.as_view(), name="tiers.edit"),
-    path("admin/global/business/tiers/<int:pk>/draft/", views.TierNewDraftView.as_view(), name="tiers.draft"),
-    path("admin/global/business/tiers/<int:pk>/publish/", views.TierPublishView.as_view(), name="tiers.publish"),
-    path("admin/global/business/tiers/<int:pk>/archive/", views.TierArchiveView.as_view(), name="tiers.archive"),
-    
-    path("admin/global/business/subscriptions/", views.SubscriptionListView.as_view(), name="subscriptions.list"),
-    path("admin/global/business/subscriptions/create/", views.SubscriptionCreateView.as_view(), name="subscriptions.create"),
-    path("admin/global/business/subscriptions/<int:pk>/edit/", views.SubscriptionUpdateView.as_view(), name="subscriptions.edit"),
-    
+    path(
+        "admin/global/business/tiers/", views.TierListView.as_view(), name="tiers.list"
+    ),
+    path(
+        "admin/global/business/tiers/create/",
+        views.TierCreateView.as_view(),
+        name="tiers.create",
+    ),
+    path(
+        "admin/global/business/tiers/<int:pk>/",
+        views.TierDetailView.as_view(),
+        name="tiers.detail",
+    ),
+    path(
+        "admin/global/business/tiers/<int:pk>/edit/",
+        views.TierUpdateView.as_view(),
+        name="tiers.edit",
+    ),
+    path(
+        "admin/global/business/tiers/<int:pk>/draft/",
+        views.TierNewDraftView.as_view(),
+        name="tiers.draft",
+    ),
+    path(
+        "admin/global/business/tiers/<int:pk>/publish/",
+        views.TierPublishView.as_view(),
+        name="tiers.publish",
+    ),
+    path(
+        "admin/global/business/tiers/<int:pk>/archive/",
+        views.TierArchiveView.as_view(),
+        name="tiers.archive",
+    ),
+    path(
+        "admin/global/business/subscriptions/",
+        views.SubscriptionListView.as_view(),
+        name="subscriptions.list",
+    ),
+    path(
+        "admin/global/business/subscriptions/create/",
+        views.SubscriptionCreateView.as_view(),
+        name="subscriptions.create",
+    ),
+    path(
+        "admin/global/business/subscriptions/<int:pk>/edit/",
+        views.SubscriptionUpdateView.as_view(),
+        name="subscriptions.edit",
+    ),
     # Organizer URLs
-    path("control/organizer/<str:organizer>/business/plan/", views.OrganizerPlanView.as_view(), name="organizer.plan"),
+    path(
+        "control/organizer/<str:organizer>/business/plan/",
+        views.OrganizerPlanView.as_view(),
+        name="organizer.plan",
+    ),
 ]

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -27,18 +27,23 @@ class TierCreateView(AdministratorPermissionRequiredMixin, CreateView):
     model = Tier
     form_class = TierForm
     template_name = "eventyay_business/tiers/form.html"
-    
+
     @transaction.atomic
     def form_valid(self, form):
         self.object = form.save()
         # Create the initial draft TierVersion
         TierVersion.objects.create(
-            tier=self.object,
-            version=1,
-            created_by=self.request.user
+            tier=self.object, version=1, created_by=self.request.user
         )
-        messages.success(self.request, _("Tier created successfully. You can now add prices and entitlements."))
-        return redirect(reverse("plugins:eventyay_business:tiers.edit", kwargs={"pk": self.object.pk}))
+        messages.success(
+            self.request,
+            _("Tier created successfully. You can now add prices and entitlements."),
+        )
+        return redirect(
+            reverse(
+                "plugins:eventyay_business:tiers.edit", kwargs={"pk": self.object.pk}
+            )
+        )
 
 
 class TierUpdateView(AdministratorPermissionRequiredMixin, UpdateView):
@@ -49,32 +54,43 @@ class TierUpdateView(AdministratorPermissionRequiredMixin, UpdateView):
     def dispatch(self, request, *args, **kwargs):
         self.object = self.get_object()
         self.latest_version = self.object.versions.first()
-        
+
         if not self.latest_version:
             self.latest_version = TierVersion.objects.create(
-                tier=self.object,
-                version=1,
-                created_by=request.user
+                tier=self.object, version=1, created_by=request.user
             )
-            
+
         # If the latest version is published, redirect to detail view or duplicate prompt
         if self.latest_version and self.latest_version.published_at:
             messages.info(
-                request, 
-                _("This tier is published. To edit prices or entitlements, please create a new draft version.")
+                request,
+                _(
+                    "This tier is published. To edit prices or entitlements, please create a new draft version."
+                ),
             )
-            return redirect(reverse("plugins:eventyay_business:tiers.detail", kwargs={"pk": self.object.pk}))
-            
+            return redirect(
+                reverse(
+                    "plugins:eventyay_business:tiers.detail",
+                    kwargs={"pk": self.object.pk},
+                )
+            )
+
         return super().dispatch(request, *args, **kwargs)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         if self.request.POST:
-            context["price_formset"] = TierPriceFormSet(self.request.POST, instance=self.latest_version)
-            context["entitlement_formset"] = TierEntitlementFormSet(self.request.POST, instance=self.latest_version)
+            context["price_formset"] = TierPriceFormSet(
+                self.request.POST, instance=self.latest_version
+            )
+            context["entitlement_formset"] = TierEntitlementFormSet(
+                self.request.POST, instance=self.latest_version
+            )
         else:
             context["price_formset"] = TierPriceFormSet(instance=self.latest_version)
-            context["entitlement_formset"] = TierEntitlementFormSet(instance=self.latest_version)
+            context["entitlement_formset"] = TierEntitlementFormSet(
+                instance=self.latest_version
+            )
         return context
 
     @transaction.atomic
@@ -83,11 +99,27 @@ class TierUpdateView(AdministratorPermissionRequiredMixin, UpdateView):
         price_formset = context["price_formset"]
         entitlement_formset = context["entitlement_formset"]
 
-        if form.is_valid() and price_formset.is_valid() and entitlement_formset.is_valid():
-            latest_version = TierVersion.objects.select_for_update().filter(pk=self.latest_version.pk).first()
+        if (
+            form.is_valid()
+            and price_formset.is_valid()
+            and entitlement_formset.is_valid()
+        ):
+            latest_version = (
+                TierVersion.objects.select_for_update()
+                .filter(pk=self.latest_version.pk)
+                .first()
+            )
             if latest_version and latest_version.published_at:
-                messages.error(self.request, _("Cannot save edits: this version was published concurrently."))
-                return redirect(reverse("plugins:eventyay_business:tiers.detail", kwargs={"pk": self.object.pk}))
+                messages.error(
+                    self.request,
+                    _("Cannot save edits: this version was published concurrently."),
+                )
+                return redirect(
+                    reverse(
+                        "plugins:eventyay_business:tiers.detail",
+                        kwargs={"pk": self.object.pk},
+                    )
+                )
 
             self.object = form.save()
             price_formset.save()
@@ -111,37 +143,44 @@ class TierDetailView(AdministratorPermissionRequiredMixin, DetailView):
 
 class TierNewDraftView(AdministratorPermissionRequiredMixin, View):
     """Creates a new DRAFT TierVersion from the latest PUBLISHED version."""
-    
+
     @transaction.atomic
     def post(self, request, *args, **kwargs):
         tier = get_object_or_404(Tier.objects.select_for_update(), pk=kwargs.get("pk"))
         latest_version = tier.versions.first()
-        
+
         if not latest_version or not latest_version.published_at:
-            messages.error(request, _("Cannot create a new draft: there is already an unpublished draft."))
-            return redirect(reverse("plugins:eventyay_business:tiers.edit", kwargs={"pk": tier.pk}))
-            
+            messages.error(
+                request,
+                _("Cannot create a new draft: there is already an unpublished draft."),
+            )
+            return redirect(
+                reverse("plugins:eventyay_business:tiers.edit", kwargs={"pk": tier.pk})
+            )
+
         # Duplicate version
         new_version = TierVersion.objects.create(
-            tier=tier,
-            version=latest_version.version + 1,
-            created_by=request.user
+            tier=tier, version=latest_version.version + 1, created_by=request.user
         )
-        
+
         # Duplicate prices
         for price in latest_version.prices.all():
             price.pk = None
             price.tier_version = new_version
             price.save()
-            
+
         # Duplicate entitlements
         for ent in latest_version.entitlements.all():
             ent.pk = None
             ent.tier_version = new_version
             ent.save()
-            
-        messages.success(request, _("New draft version created. You can now make changes."))
-        return redirect(reverse("plugins:eventyay_business:tiers.edit", kwargs={"pk": tier.pk}))
+
+        messages.success(
+            request, _("New draft version created. You can now make changes.")
+        )
+        return redirect(
+            reverse("plugins:eventyay_business:tiers.edit", kwargs={"pk": tier.pk})
+        )
 
 
 class TierPublishView(AdministratorPermissionRequiredMixin, View):
@@ -149,23 +188,26 @@ class TierPublishView(AdministratorPermissionRequiredMixin, View):
     def post(self, request, *args, **kwargs):
         tier = get_object_or_404(Tier, pk=kwargs.get("pk"))
         latest_version = tier.versions.first()
-        
+
         if tier.status == TierStatus.ARCHIVED:
-            messages.error(request, _("Cannot publish a draft for an archived tier. Unarchive it first."))
+            messages.error(
+                request,
+                _("Cannot publish a draft for an archived tier. Unarchive it first."),
+            )
             return redirect(reverse("plugins:eventyay_business:tiers.list"))
 
         if latest_version and not latest_version.published_at:
             latest_version.published_at = now()
             latest_version.save()
-            
+
             if tier.status == TierStatus.DRAFT:
                 tier.status = TierStatus.PUBLISHED
                 tier.save()
-                
+
             messages.success(request, _("Tier published successfully."))
         else:
             messages.error(request, _("This tier has no unpublished draft."))
-            
+
         return redirect(reverse("plugins:eventyay_business:tiers.list"))
 
 
@@ -179,22 +221,25 @@ class TierArchiveView(AdministratorPermissionRequiredMixin, View):
         return redirect(reverse("plugins:eventyay_business:tiers.list"))
 
 
-from .models import Subscription
 from .forms import SubscriptionAdminForm
+from .models import Subscription
+
 
 class SubscriptionListView(AdministratorPermissionRequiredMixin, ListView):
     model = Subscription
     template_name = "eventyay_business/subscriptions/list.html"
     context_object_name = "subscriptions"
 
+
 class SubscriptionCreateView(AdministratorPermissionRequiredMixin, CreateView):
     model = Subscription
     form_class = SubscriptionAdminForm
     template_name = "eventyay_business/subscriptions/form.html"
-    
+
     def get_success_url(self):
         messages.success(self.request, _("Subscription created successfully."))
         return reverse("plugins:eventyay_business:subscriptions.list")
+
 
 class SubscriptionUpdateView(AdministratorPermissionRequiredMixin, UpdateView):
     model = Subscription
@@ -205,48 +250,63 @@ class SubscriptionUpdateView(AdministratorPermissionRequiredMixin, UpdateView):
         messages.success(self.request, _("Subscription updated successfully."))
         return reverse("plugins:eventyay_business:subscriptions.list")
 
-from eventyay.control.permissions import OrganizerPermissionRequiredMixin
-from eventyay.control.views.organizer_views.organizer_detail_view_mixin import OrganizerDetailViewMixin
+
 from django.views.generic import TemplateView
+from eventyay.control.permissions import OrganizerPermissionRequiredMixin
+from eventyay.control.views.organizer_views.organizer_detail_view_mixin import (
+    OrganizerDetailViewMixin,
+)
+
 from .capabilities import get_all_capabilities
 
-class OrganizerPlanView(OrganizerPermissionRequiredMixin, OrganizerDetailViewMixin, TemplateView):
+
+class OrganizerPlanView(
+    OrganizerPermissionRequiredMixin, OrganizerDetailViewMixin, TemplateView
+):
     permission = "can_change_organizer_settings"
     template_name = "eventyay_business/organizer/plan.html"
 
     def get_context_data(self, **kwargs):
         ctx = super().get_context_data(**kwargs)
         organizer = self.request.organizer
-        from .models import Subscription
-        
         from django.utils.timezone import now
+
+        from .models import Subscription
+
         current_time = now()
-        sub = Subscription.objects.filter(
-            organizer=organizer,
-            status="active",
-            starts_at__lte=current_time,
-        ).exclude(
-            ends_at__lt=current_time
-        ).select_related('tier_version__tier').first()
-        
-        ctx['subscription'] = sub
-        
+        sub = (
+            Subscription.objects.filter(
+                organizer=organizer,
+                status="active",
+                starts_at__lte=current_time,
+            )
+            .exclude(ends_at__lt=current_time)
+            .select_related("tier_version__tier")
+            .first()
+        )
+
+        ctx["subscription"] = sub
+
         # Build a complete picture of effective entitlements
         effective_entitlements = []
         all_caps = get_all_capabilities()
-        
+
         override_dict = {}
         if sub and sub.tier_version:
             for ent in sub.tier_version.entitlements.all():
                 override_dict[ent.capability] = ent.get_typed_value()
-                
+
         for cap in all_caps:
             val = override_dict.get(cap.name, cap.default_value)
-            effective_entitlements.append({
-                'capability': cap,
-                'effective_value': val,
-                'is_overridden': cap.name in override_dict
-            })
-            
-        ctx['effective_entitlements'] = sorted(effective_entitlements, key=lambda x: x['capability'].category)
+            effective_entitlements.append(
+                {
+                    "capability": cap,
+                    "effective_value": val,
+                    "is_overridden": cap.name in override_dict,
+                }
+            )
+
+        ctx["effective_entitlements"] = sorted(
+            effective_entitlements, key=lambda x: x["capability"].category
+        )
         return ctx

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -1,5 +1,5 @@
 try:
-    from eventyay.config.settings import *
+    from eventyay.config.settings import *  # noqa: F403, F401
 except ImportError:
     pass
 

--- a/tests/test_capabilities.py
+++ b/tests/test_capabilities.py
@@ -162,7 +162,9 @@ def test_tier_entitlement_typed_value():
     assert ent_dec.get_typed_value() == Decimal("2.5")
 
     # Money capability
-    ent_money = TierEntitlement(capability="registration.free_overage_price", value="0.50")
+    ent_money = TierEntitlement(
+        capability="registration.free_overage_price", value="0.50"
+    )
     assert ent_money.get_typed_value() == Decimal("0.50")
 
     # Boolean capability
@@ -186,7 +188,10 @@ def test_tier_entitlement_form_validation():
 
     # Invalid decimal for commerce.platform_fee_percent
     form_invalid = TierEntitlementForm()
-    form_invalid.cleaned_data = {"capability": "commerce.platform_fee_percent", "value": "not-a-number"}
+    form_invalid.cleaned_data = {
+        "capability": "commerce.platform_fee_percent",
+        "value": "not-a-number",
+    }
     form_invalid.clean()
     assert "value" in form_invalid.errors
 
@@ -199,6 +204,9 @@ def test_tier_entitlement_form_validation():
 
     # Invalid integer for organizer.full_admins
     form_int_invalid = TierEntitlementForm()
-    form_int_invalid.cleaned_data = {"capability": "organizer.full_admins", "value": "2.5"}
+    form_int_invalid.cleaned_data = {
+        "capability": "organizer.full_admins",
+        "value": "2.5",
+    }
     form_int_invalid.clean()
     assert "value" in form_int_invalid.errors

--- a/tests/test_entitlement_receiver.py
+++ b/tests/test_entitlement_receiver.py
@@ -1,15 +1,20 @@
 import pytest
 from django.utils.timezone import now
-from unittest.mock import MagicMock
 
+from eventyay.base.entitlements import check_entitlement
 from eventyay.base.models import Organizer
-from eventyay.base.entitlements import EntitlementDecision, check_entitlement
-from eventyay_business.models import Subscription, Tier, TierVersion, TierEntitlement
-from eventyay_business.capabilities import Capability, CapabilityValueType, register_capability
+from eventyay_business.capabilities import (
+    Capability,
+    CapabilityValueType,
+    register_capability,
+)
+from eventyay_business.models import Subscription, Tier, TierEntitlement, TierVersion
+
 
 @pytest.fixture
 def dummy_organizer():
     return Organizer.objects.create(name="Test Organizer", slug="test-org")
+
 
 @pytest.fixture
 def business_setup(dummy_organizer):
@@ -18,25 +23,26 @@ def business_setup(dummy_organizer):
     sub = Subscription.objects.get(organizer=dummy_organizer)
     sub.tier_version = version
     sub.save(update_fields=["tier_version"])
-    
+
     # Register a test capability
     cap = Capability(
         name="test.bool",
         label="Test Boolean",
         value_type=CapabilityValueType.BOOLEAN,
-        default_value=False
+        default_value=False,
     )
     register_capability(cap, override=True)
-    
+
     cap_int = Capability(
         name="test.int",
         label="Test Integer",
         value_type=CapabilityValueType.INTEGER,
-        default_value=10
+        default_value=10,
     )
     register_capability(cap_int, override=True)
-    
+
     return tier, version, sub
+
 
 @pytest.mark.django_db
 def test_receiver_boolean_default_deny(dummy_organizer, business_setup):
@@ -45,14 +51,18 @@ def test_receiver_boolean_default_deny(dummy_organizer, business_setup):
     assert decision.allowed is False
     assert decision.reason_code == "tier_restriction"
 
+
 @pytest.mark.django_db
 def test_receiver_boolean_explicit_allow(dummy_organizer, business_setup):
     """If an explicit override exists, it should use it."""
     tier, version, sub = business_setup
-    TierEntitlement.objects.create(tier_version=version, capability="test.bool", value="true")
-    
+    TierEntitlement.objects.create(
+        tier_version=version, capability="test.bool", value="true"
+    )
+
     decision = check_entitlement(dummy_organizer, capability="test.bool")
     assert decision.allowed is True
+
 
 @pytest.mark.django_db
 def test_receiver_integer_default_allow(dummy_organizer, business_setup):
@@ -60,6 +70,7 @@ def test_receiver_integer_default_allow(dummy_organizer, business_setup):
     decision = check_entitlement(dummy_organizer, capability="test.int", quantity=5)
     assert decision.allowed is True
     assert decision.limit == 10
+
 
 @pytest.mark.django_db
 def test_receiver_integer_default_deny(dummy_organizer, business_setup):
@@ -69,12 +80,15 @@ def test_receiver_integer_default_deny(dummy_organizer, business_setup):
     assert decision.reason_code == "tier_limit_exceeded"
     assert decision.limit == 10
 
+
 @pytest.mark.django_db
 def test_receiver_integer_explicit_override(dummy_organizer, business_setup):
     """Explicit override changes the limit."""
     tier, version, sub = business_setup
-    TierEntitlement.objects.create(tier_version=version, capability="test.int", value="20")
-    
+    TierEntitlement.objects.create(
+        tier_version=version, capability="test.int", value="20"
+    )
+
     decision = check_entitlement(dummy_organizer, capability="test.int", quantity=15)
     assert decision.allowed is True
     assert decision.limit == 20

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,17 +1,16 @@
 import pytest
-from django.utils.timezone import now
 from eventyay.base.models import Organizer
-from eventyay_business.models import Subscription, Tier, TierVersion
+
+from eventyay_business.models import Subscription
+
 
 @pytest.mark.django_db
 def test_organizer_auto_assign_free_tier():
     # Creating an organizer should trigger the post_save signal
     org = Organizer.objects.create(name="Test Organizer", slug="test-org")
-    
+
     # Check if a subscription was created
     sub = Subscription.objects.filter(organizer=org).first()
     assert sub is not None
     assert sub.status == "active"
     assert sub.tier_version.tier.slug == "free"
-
-

--- a/tests/test_tier_admin.py
+++ b/tests/test_tier_admin.py
@@ -1,17 +1,21 @@
 import pytest
 from django.urls import reverse
-from eventyay_business.models import Tier, TierVersion, TierStatus
+
+from eventyay_business.models import Tier, TierStatus, TierVersion
+
 
 @pytest.fixture
 def business_admin_client(admin_client):
     # Depending on Eventyay setup, admin_client might just work.
     return admin_client
 
+
 @pytest.fixture
 def sample_tier():
     tier = Tier.objects.create(name="Pro", slug="pro", status=TierStatus.DRAFT)
     TierVersion.objects.create(tier=tier, version=1)
     return tier
+
 
 @pytest.mark.django_db
 def test_tier_list_view(business_admin_client, sample_tier):
@@ -20,23 +24,28 @@ def test_tier_list_view(business_admin_client, sample_tier):
     assert response.status_code == 200
     assert "Pro" in response.content.decode()
 
+
 @pytest.mark.django_db
 def test_tier_create_view(business_admin_client):
     url = reverse("plugins:eventyay_business:tiers.create")
-    response = business_admin_client.post(url, {
-        "name": "Enterprise",
-        "slug": "enterprise",
-        "description": "Top tier",
-        "is_public": "on",
-        "display_order": "1"
-    })
+    response = business_admin_client.post(
+        url,
+        {
+            "name": "Enterprise",
+            "slug": "enterprise",
+            "description": "Top tier",
+            "is_public": "on",
+            "display_order": "1",
+        },
+    )
     assert response.status_code == 302
-    
+
     tier = Tier.objects.get(slug="enterprise")
     assert tier.versions.count() == 1
     version = tier.versions.first()
     assert version.version == 1
     assert version.published_at is None
+
 
 @pytest.mark.django_db
 def test_tier_new_draft_view(business_admin_client, sample_tier):
@@ -47,10 +56,12 @@ def test_tier_new_draft_view(business_admin_client, sample_tier):
     sample_tier.status = TierStatus.PUBLISHED
     sample_tier.save()
 
-    url = reverse("plugins:eventyay_business:tiers.draft", kwargs={"pk": sample_tier.pk})
+    url = reverse(
+        "plugins:eventyay_business:tiers.draft", kwargs={"pk": sample_tier.pk}
+    )
     response = business_admin_client.post(url)
     assert response.status_code == 302
-    
+
     assert sample_tier.versions.count() == 2
     v2 = sample_tier.versions.order_by("-version").first()
     assert v2.version == 2


### PR DESCRIPTION
Fixes failing CI checks on the dev branch:
- Runs black and isort to format missing files
- Adds noqa comments for acceptable unused imports
- Adds __init__.py to the tests directory so pytest-django can correctly resolve the tests.settings module.

## Summary by Sourcery

Fix formatting and test configuration issues so the business plugin passes CI checks.

Bug Fixes:
- Resolve CI failures caused by formatting checks, unused-import linting, and pytest-django test configuration.

Enhancements:
- Standardize Python formatting and import ordering across the business plugin and its tests.

Tests:
- Adjust the test settings and test files so the Django test suite can be discovered and run successfully.