### PR TITLE
fix(nav): restrict Tiers and Subscriptions to global admin area

### DIFF
--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -34,7 +34,11 @@ if nav_global:
             return []
 
         user = getattr(request, "user", None)
-        if not user or not user.is_authenticated or not (user.is_staff or user.is_superuser):
+        if (
+            not user
+            or not user.is_authenticated
+            or not (user.is_staff or user.is_superuser)
+        ):
             return []
 
         path = getattr(request, "path_info", "") or getattr(request, "path", "")

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -33,6 +33,25 @@ if nav_global:
         if not url:
             return []
 
+        user = getattr(request, "user", None)
+        if not user or not user.is_authenticated or not (user.is_staff or user.is_superuser):
+            return []
+
+        path = getattr(request, "path_info", "") or getattr(request, "path", "")
+        # Tiers and Subscriptions are global administrative configuration.
+        # Only show them in the admin navigation area, not in public-facing or common user dashboards.
+        is_admin_area = (
+            url.namespace == "eventyay_admin"
+            or (
+                url.namespace == "plugins:eventyay_business"
+                and not url.url_name.startswith("organizer.")
+            )
+            or url.url_name.startswith("admin.")
+            or path.startswith("/admin/")
+        )
+        if not is_admin_area:
+            return []
+
         return [
             {
                 "label": _("Tiers"),

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -1,7 +1,6 @@
-from unittest.mock import Mock
-
 from django.test import RequestFactory
 from django.urls import ResolverMatch
+from unittest.mock import Mock
 
 from eventyay_business.signals import business_tiers_nav
 

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -1,0 +1,118 @@
+from unittest.mock import Mock
+
+from django.test import RequestFactory
+from django.urls import ResolverMatch
+
+from eventyay_business.signals import business_tiers_nav
+
+
+def test_business_tiers_nav_anonymous():
+    factory = RequestFactory()
+    request = factory.get("/common")
+    request.user = Mock(is_authenticated=False, is_staff=False, is_superuser=False)
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs={},
+        url_name="dashboard",
+        app_names=["eventyay_common"],
+        namespaces=["eventyay_common"],
+    )
+
+    items = business_tiers_nav(sender=None, request=request)
+    assert items == []
+
+
+def test_business_tiers_nav_non_staff_authenticated():
+    factory = RequestFactory()
+    request = factory.get("/common")
+    request.user = Mock(is_authenticated=True, is_staff=False, is_superuser=False)
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs={},
+        url_name="dashboard",
+        app_names=["eventyay_common"],
+        namespaces=["eventyay_common"],
+    )
+
+    items = business_tiers_nav(sender=None, request=request)
+    assert items == []
+
+
+def test_business_tiers_nav_staff_on_common_dashboard():
+    """Verify that staff visiting public-facing common dashboard do not see Tiers/Subscriptions."""
+    factory = RequestFactory()
+    request = factory.get("/common")
+    request.user = Mock(is_authenticated=True, is_staff=True, is_superuser=False)
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs={},
+        url_name="dashboard",
+        app_names=["eventyay_common"],
+        namespaces=["eventyay_common"],
+    )
+
+    items = business_tiers_nav(sender=None, request=request)
+    assert items == []
+
+
+def test_business_tiers_nav_staff_on_organizer_plan():
+    """Verify that organizer plan route does not show global business tiers nav."""
+    factory = RequestFactory()
+    request = factory.get("/control/organizer/test-org/business/plan/")
+    request.user = Mock(is_authenticated=True, is_staff=True, is_superuser=False)
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs={"organizer": "test-org"},
+        url_name="organizer.plan",
+        app_names=["plugins:eventyay_business"],
+        namespaces=["plugins:eventyay_business"],
+    )
+
+    items = business_tiers_nav(sender=None, request=request)
+    assert items == []
+
+
+def test_business_tiers_nav_staff_on_admin_page():
+    """Verify that staff on admin routes get Tiers and Subscriptions in navigation."""
+    factory = RequestFactory()
+    request = factory.get("/admin/global/business/")
+    request.user = Mock(is_authenticated=True, is_staff=True, is_superuser=False)
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs={},
+        url_name="admin.global.business",
+        app_names=["eventyay_admin"],
+        namespaces=["eventyay_admin"],
+    )
+
+    items = business_tiers_nav(sender=None, request=request)
+    assert len(items) == 2
+    assert str(items[0]["label"]) == "Tiers"
+    assert str(items[1]["label"]) == "Subscriptions"
+    assert items[0]["active"] is False
+    assert items[1]["active"] is False
+
+
+def test_business_tiers_nav_staff_on_tiers_list():
+    """Verify that staff on tiers list view have Tiers marked active."""
+    factory = RequestFactory()
+    request = factory.get("/admin/global/business/tiers/")
+    request.user = Mock(is_authenticated=True, is_staff=True, is_superuser=False)
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs={},
+        url_name="tiers.list",
+        app_names=["plugins:eventyay_business"],
+        namespaces=["plugins:eventyay_business"],
+    )
+
+    items = business_tiers_nav(sender=None, request=request)
+    assert len(items) == 2
+    assert items[0]["active"] is True
+    assert items[1]["active"] is False


### PR DESCRIPTION

<img width="5088" height="3364" alt="image" src="https://github.com/user-attachments/assets/1cd0516a-d1f9-4dea-99fb-f408b696dd65" />


## Summary
Previously, the `business_tiers_nav` signal receiver responded unconditionally to `nav_global`. Because `nav_global` is also dispatched when constructing the user/common dashboard (`/common`), `Tiers` and `Subscriptions` were appearing at the root of the sidebar on public-facing dashboard pages for both users and staff.

## Changes
1. **Permission Guard**: Only return `Tiers` and `Subscriptions` if `request.user` is authenticated and is staff/superuser.
2. **Context Guard**: Only return `Tiers` and `Subscriptions` when the request is in the global admin section (`/admin/`), ensuring they remain under **Business** in the global admin navigation and do not leak into public-facing/common user dashboards.
3. **Tests**: Added unit tests in `tests/test_nav.py` verifying behavior across anonymous, non-staff, public-facing staff (`/common`), and admin routes.

## Summary by Sourcery

Keep business tier navigation confined to the global administrative area.

Bug Fixes:
- Restrict Tiers and Subscriptions navigation items to authenticated staff or superusers within the global admin area, preventing them from appearing on public-facing and common dashboards.

Tests:
- Add navigation coverage for anonymous users, non-staff users, staff on common and organizer pages, and staff on admin routes.