### PR TITLE
feat: seed standard entitlements and publish Free tier by default

### DIFF
--- a/eventyay_business/migrations/0007_seed_free_tier_entitlements.py
+++ b/eventyay_business/migrations/0007_seed_free_tier_entitlements.py
@@ -1,0 +1,77 @@
+from django.db import migrations
+
+
+def seed_free_tier_entitlements(apps, schema_editor):
+    Tier = apps.get_model("eventyay_business", "Tier")
+    TierVersion = apps.get_model("eventyay_business", "TierVersion")
+    TierEntitlement = apps.get_model("eventyay_business", "TierEntitlement")
+
+    free_tier = Tier.objects.filter(slug="free").first()
+    if not free_tier:
+        return
+
+    if free_tier.status == "draft":
+        free_tier.status = "published"
+        free_tier.save(update_fields=["status"])
+
+    versions = list(free_tier.versions.all())
+    if not versions:
+        v1 = TierVersion.objects.create(
+            tier=free_tier,
+            version=1,
+            published_at=free_tier.created_at,
+        )
+        versions = [v1]
+
+    # Standard capabilities definition to seed
+    standard_defaults = [
+        ("video.youtube", "true", "", False),
+        ("video.jitsi", "true", "", False),
+        ("video.jitsi.concurrent_rooms", "1", "rooms", False),
+        ("video.loungemesh", "false", "", False),
+        ("email.bulk.monthly", "1000", "emails", False),
+        ("organizer.full_admins", "2", "admins", False),
+        ("api.read", "true", "", False),
+        ("api.write", "false", "", False),
+        ("api.webhooks", "false", "", False),
+        ("commerce.platform_fee_percent", "0.0", "%", False),
+        ("registration.free_allowance_per_event", "100", "registrations", False),
+        ("registration.free_overage_price", "0.0", "per registration", False),
+        ("support.priority", "false", "", False),
+    ]
+
+    for version in versions:
+        if version.published_at is None:
+            version.published_at = free_tier.created_at
+            version.save(update_fields=["published_at"])
+
+        existing_caps = set(
+            TierEntitlement.objects.filter(tier_version=version).values_list(
+                "capability", flat=True
+            )
+        )
+        to_create = []
+        for cap_name, val, unit, overage in standard_defaults:
+            if cap_name not in existing_caps:
+                to_create.append(
+                    TierEntitlement(
+                        tier_version=version,
+                        capability=cap_name,
+                        value=val,
+                        unit=unit,
+                        overage_allowed=overage,
+                    )
+                )
+        if to_create:
+            TierEntitlement.objects.bulk_create(to_create)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("eventyay_business", "0006_usagerecord"),
+    ]
+
+    operations = [
+        migrations.RunPython(seed_free_tier_entitlements, migrations.RunPython.noop),
+    ]

--- a/eventyay_business/services.py
+++ b/eventyay_business/services.py
@@ -51,3 +51,46 @@ def record_usage(
 
         # Re-raise all other integrity errors
         raise
+
+
+def seed_standard_entitlements_for_version(tier_version, TierEntitlementModel=None):
+    """
+    Populates standard catalogue capabilities as TierEntitlement database records
+    for the given tier_version if they do not already exist.
+    """
+    if TierEntitlementModel is None:
+        from .models import TierEntitlement as TierEntitlementModel
+
+    from .capabilities import STANDARD_CAPABILITIES, CapabilityValueType
+
+    existing_caps = set(
+        TierEntitlementModel.objects.filter(tier_version=tier_version).values_list(
+            "capability", flat=True
+        )
+    )
+
+    entitlements_to_create = []
+    for cap in STANDARD_CAPABILITIES:
+        if cap.name in existing_caps:
+            continue
+
+        raw_val = cap.default_value
+        if cap.value_type == CapabilityValueType.BOOLEAN:
+            str_val = "true" if raw_val else "false"
+        elif raw_val is not None:
+            str_val = str(raw_val)
+        else:
+            str_val = ""
+
+        entitlements_to_create.append(
+            TierEntitlementModel(
+                tier_version=tier_version,
+                capability=cap.name,
+                value=str_val,
+                unit=cap.unit or "",
+                overage_allowed=False,
+            )
+        )
+
+    if entitlements_to_create:
+        TierEntitlementModel.objects.bulk_create(entitlements_to_create)

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -97,7 +97,14 @@ def auto_assign_free_tier(sender, instance, created, **kwargs):
     if not created:
         return
 
-    from .models import Subscription, SubscriptionStatus, Tier, TierVersion
+    from .models import (
+        Subscription,
+        SubscriptionStatus,
+        Tier,
+        TierStatus,
+        TierVersion,
+    )
+    from .services import seed_standard_entitlements_for_version
 
     free_tier, _ = Tier.objects.get_or_create(
         slug="free",
@@ -105,8 +112,12 @@ def auto_assign_free_tier(sender, instance, created, **kwargs):
             "name": "Free",
             "description": "Default free tier",
             "is_public": True,
+            "status": TierStatus.PUBLISHED,
         },
     )
+    if free_tier.status == TierStatus.DRAFT:
+        free_tier.status = TierStatus.PUBLISHED
+        free_tier.save(update_fields=["status"])
 
     latest_version = (
         free_tier.versions.filter(published_at__isnull=False)
@@ -117,6 +128,11 @@ def auto_assign_free_tier(sender, instance, created, **kwargs):
         latest_version, _ = TierVersion.objects.get_or_create(
             tier=free_tier, version=1, defaults={"published_at": now()}
         )
+        if latest_version.published_at is None:
+            latest_version.published_at = now()
+            latest_version.save(update_fields=["published_at"])
+
+    seed_standard_entitlements_for_version(latest_version)
 
     Subscription.objects.create(
         organizer=instance,

--- a/tests/test_seed_entitlements.py
+++ b/tests/test_seed_entitlements.py
@@ -1,0 +1,55 @@
+from unittest.mock import Mock
+
+from eventyay_business.capabilities import STANDARD_CAPABILITIES
+from eventyay_business.services import seed_standard_entitlements_for_version
+
+
+def test_seed_standard_entitlements_for_version():
+    class DummyEntitlement:
+        def __init__(self, tier_version, capability, value, unit, overage_allowed):
+            self.tier_version = tier_version
+            self.capability = capability
+            self.value = value
+            self.unit = unit
+            self.overage_allowed = overage_allowed
+
+    created_records = []
+
+    class DummyManager:
+        def filter(self, **kwargs):
+            return self
+
+        def values_list(self, field, flat=True):
+            return [r.capability for r in created_records]
+
+        def bulk_create(self, records):
+            created_records.extend(records)
+
+    DummyModel = Mock()
+    DummyModel.objects = DummyManager()
+    DummyModel.side_effect = DummyEntitlement
+
+    mock_version = Mock(id=1)
+
+    # First call: seeds all 13 capabilities
+    seed_standard_entitlements_for_version(
+        mock_version, TierEntitlementModel=DummyModel
+    )
+    assert len(created_records) == len(STANDARD_CAPABILITIES)
+    assert len(created_records) == 13
+
+    # Verify specific capability values
+    seeded = {r.capability: r for r in created_records}
+    assert seeded["organizer.full_admins"].value == "2"
+    assert seeded["organizer.full_admins"].unit == "admins"
+    assert seeded["email.bulk.monthly"].value == "1000"
+    assert seeded["registration.free_allowance_per_event"].value == "100"
+    assert seeded["video.youtube"].value == "true"
+    assert seeded["api.write"].value == "false"
+
+    # Second call: idempotent, does not re-add existing capabilities
+    initial_count = len(created_records)
+    seed_standard_entitlements_for_version(
+        mock_version, TierEntitlementModel=DummyModel
+    )
+    assert len(created_records) == initial_count


### PR DESCRIPTION
## Summary
Previously, when the Free tier was auto-created, only empty `Tier` and `TierVersion` shell records were created in the database without corresponding `TierEntitlement` rows. While runtime limits fell back to catalogue defaults in code, the admin UI displayed **"No entitlements defined" (0 entitlements)** and **"Draft"**, making it appear that the Free tier had no entitlements configured and leaving new draft clones empty.

## Changes
1. **Data Migration (`0007_seed_free_tier_entitlements`)**:
   - Updates existing Free tier status from `draft` to `published`.
   - Seeds all 13 standard platform capabilities with their catalogue defaults into `TierEntitlement` database records for the Free tier version.
2. **Auto-Assignment Receiver (`signals.py`)**:
   - Ensures any Free tier created on a fresh installation is set to `status=TierStatus.PUBLISHED`.
   - Automatically calls `seed_standard_entitlements_for_version` so the database is pre-populated with all 13 standard entitlements right away.
3. **Helper (`services.py`)**:
   - Added `seed_standard_entitlements_for_version` to idempotently populate standard capability entitlements.
4. **Tests**:
   - Added unit tests in `tests/test_seed_entitlements.py` verifying correct seeding of all 13 capabilities, proper types/units, and idempotency.

## Summary by Sourcery

Publish the default Free tier and populate it with standard entitlements so its configuration is available immediately.

New Features:
- Seed the Free tier with all standard catalogue entitlements and publish it by default for existing and newly created installations.

Bug Fixes:
- Ensure the Free tier and its version are published and visibly configured instead of appearing as an empty draft.

Enhancements:
- Add idempotent entitlement seeding for tier versions using standard capability defaults.

Tests:
- Add coverage for seeding all standard capabilities, including values and units, and verifying idempotency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Free-tier plans are now automatically published with standard entitlements.
  - Newly created free-tier versions receive the complete set of standard capabilities and default values.
  - Existing free-tier configurations are backfilled with missing entitlements.

- **Bug Fixes**
  - Prevented duplicate entitlements when standard capabilities are assigned repeatedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->