### PR TITLE
feat: option to migrate existing subscribers when publishing a new tier version

### DIFF
--- a/eventyay_business/services.py
+++ b/eventyay_business/services.py
@@ -99,3 +99,23 @@ def seed_standard_entitlements_for_version(tier_version, TierEntitlementModel=No
             )
         except IntegrityError:
             pass
+
+
+def migrate_tier_subscribers(tier, target_version, from_version=None):
+    """
+    Migrates active and pending subscriptions belonging to a tier (or specific from_version)
+    to target_version.
+    Returns the number of subscriptions updated.
+    """
+    from .models import Subscription, SubscriptionStatus
+
+    qs = Subscription.objects.filter(
+        status__in=[SubscriptionStatus.ACTIVE, SubscriptionStatus.PENDING]
+    )
+    if from_version:
+        qs = qs.filter(tier_version=from_version)
+    else:
+        qs = qs.filter(tier_version__tier=tier).exclude(tier_version=target_version)
+
+    count = qs.update(tier_version=target_version, updated_at=now())
+    return count

--- a/eventyay_business/services.py
+++ b/eventyay_business/services.py
@@ -109,13 +109,18 @@ def migrate_tier_subscribers(tier, target_version, from_version=None):
     """
     from .models import Subscription, SubscriptionStatus
 
+    if target_version.tier_id != tier.pk:
+        raise ValueError("Target version does not belong to the specified tier.")
+    if from_version and from_version.tier_id != tier.pk:
+        raise ValueError("From version does not belong to the specified tier.")
+
     qs = Subscription.objects.filter(
-        status__in=[SubscriptionStatus.ACTIVE, SubscriptionStatus.PENDING]
-    )
+        tier_version__tier=tier,
+        status__in=[SubscriptionStatus.ACTIVE, SubscriptionStatus.PENDING],
+    ).exclude(tier_version=target_version)
+
     if from_version:
         qs = qs.filter(tier_version=from_version)
-    else:
-        qs = qs.filter(tier_version__tier=tier).exclude(tier_version=target_version)
 
     count = qs.update(tier_version=target_version, updated_at=now())
     return count

--- a/eventyay_business/templates/eventyay_business/tiers/detail.html
+++ b/eventyay_business/templates/eventyay_business/tiers/detail.html
@@ -127,9 +127,23 @@
                             <i class="fa fa-fw fa-edit"></i> {% trans "Edit Draft" %}
                         </a>
                         {% if latest_version %}
-                            <form action="{% url 'plugins:eventyay_business:tiers.publish' pk=tier.pk %}" method="post" style="display:inline;">
+                            <form action="{% url 'plugins:eventyay_business:tiers.publish' pk=tier.pk %}" method="post">
                                 {% csrf_token %}
-                                <button class="list-group-item" onclick="return confirm('{% trans "Are you sure you want to publish this draft? It cannot be edited once published." %}');">
+                                {% if has_previous_published_version %}
+                                    <div class="list-group-item">
+                                        <div class="checkbox" style="margin: 0;">
+                                            <label>
+                                                <input type="checkbox" name="migrate_subscribers" value="1" checked>
+                                                {% blocktrans count counter=previous_subscribers_count trimmed with version=latest_version.version %}
+                                                    Migrate {{ counter }} existing subscriber to v{{ version }}
+                                                {% plural %}
+                                                    Migrate {{ counter }} existing subscribers to v{{ version }}
+                                                {% endblocktrans %}
+                                            </label>
+                                        </div>
+                                    </div>
+                                {% endif %}
+                                <button type="submit" class="list-group-item" onclick="return confirm('{% trans "Are you sure you want to publish this draft? It cannot be edited once published." %}');">
                                     <i class="fa fa-fw fa-bullhorn text-success"></i> {% trans "Publish Draft" %}
                                 </button>
                             </form>

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -13,8 +13,20 @@ from django.views.generic import (
 )
 from eventyay.control.permissions import AdministratorPermissionRequiredMixin
 
-from .forms import TierEntitlementFormSet, TierForm, TierPriceFormSet
-from .models import Tier, TierStatus, TierVersion
+from .forms import (
+    SubscriptionAdminForm,
+    TierEntitlementFormSet,
+    TierForm,
+    TierPriceFormSet,
+)
+from .models import (
+    Subscription,
+    SubscriptionStatus,
+    Tier,
+    TierStatus,
+    TierVersion,
+)
+from .services import migrate_tier_subscribers
 
 
 class TierListView(AdministratorPermissionRequiredMixin, ListView):
@@ -137,7 +149,17 @@ class TierDetailView(AdministratorPermissionRequiredMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["latest_version"] = self.object.versions.first()
+        latest_version = self.object.versions.first()
+        context["latest_version"] = latest_version
+        if latest_version and not latest_version.published_at:
+            prev_versions = self.object.versions.filter(published_at__isnull=False)
+            has_prev = prev_versions.exists()
+            context["has_previous_published_version"] = has_prev
+            if has_prev:
+                context["previous_subscribers_count"] = Subscription.objects.filter(
+                    tier_version__in=prev_versions,
+                    status__in=[SubscriptionStatus.ACTIVE, SubscriptionStatus.PENDING],
+                ).count()
         return context
 
 
@@ -204,7 +226,22 @@ class TierPublishView(AdministratorPermissionRequiredMixin, View):
                 tier.status = TierStatus.PUBLISHED
                 tier.save()
 
-            messages.success(request, _("Tier published successfully."))
+            migrate_subs = request.POST.get("migrate_subscribers") in (
+                "1",
+                "true",
+                "on",
+            )
+            if migrate_subs:
+                count = migrate_tier_subscribers(tier, latest_version)
+                messages.success(
+                    request,
+                    _(
+                        "Tier published successfully. Migrated %(count)d subscriber(s) to v%(version)d."
+                    )
+                    % {"count": count, "version": latest_version.version},
+                )
+            else:
+                messages.success(request, _("Tier published successfully."))
         else:
             messages.error(request, _("This tier has no unpublished draft."))
 
@@ -219,10 +256,6 @@ class TierArchiveView(AdministratorPermissionRequiredMixin, View):
         tier.save()
         messages.success(request, _("Tier archived successfully."))
         return redirect(reverse("plugins:eventyay_business:tiers.list"))
-
-
-from .forms import SubscriptionAdminForm
-from .models import Subscription
 
 
 class SubscriptionListView(AdministratorPermissionRequiredMixin, ListView):

--- a/tests/test_tier_admin.py
+++ b/tests/test_tier_admin.py
@@ -125,6 +125,84 @@ def test_migrate_tier_subscribers_service():
 
 
 @pytest.mark.django_db
+def test_migrate_tier_subscribers_validation():
+    tier1 = Tier.objects.create(
+        name="Pro", slug="pro-val-1", status=TierStatus.PUBLISHED
+    )
+    TierVersion.objects.create(tier=tier1, version=1, published_at=now())
+    v2_tier1 = TierVersion.objects.create(tier=tier1, version=2, published_at=now())
+
+    tier2 = Tier.objects.create(
+        name="Enterprise", slug="ent-val-2", status=TierStatus.PUBLISHED
+    )
+    v1_tier2 = TierVersion.objects.create(tier=tier2, version=1, published_at=now())
+
+    with pytest.raises(
+        ValueError, match="Target version does not belong to the specified tier."
+    ):
+        migrate_tier_subscribers(tier1, v1_tier2)
+
+    with pytest.raises(
+        ValueError, match="From version does not belong to the specified tier."
+    ):
+        migrate_tier_subscribers(tier1, v2_tier1, from_version=v1_tier2)
+
+
+@pytest.mark.django_db
+def test_migrate_tier_subscribers_with_from_version():
+    tier = Tier.objects.create(
+        name="Pro", slug="pro-scoped", status=TierStatus.PUBLISHED
+    )
+    v1 = TierVersion.objects.create(tier=tier, version=1, published_at=now())
+    v2 = TierVersion.objects.create(tier=tier, version=2, published_at=now())
+    v3 = TierVersion.objects.create(tier=tier, version=3, published_at=now())
+
+    other_tier = Tier.objects.create(
+        name="Basic", slug="basic-other", status=TierStatus.PUBLISHED
+    )
+    v1_other = TierVersion.objects.create(
+        tier=other_tier, version=1, published_at=now()
+    )
+
+    org1 = Organizer.objects.create(name="Org 1", slug="org-sc-1")
+    Subscription.objects.filter(organizer=org1).delete()
+    org2 = Organizer.objects.create(name="Org 2", slug="org-sc-2")
+    Subscription.objects.filter(organizer=org2).delete()
+    org_other = Organizer.objects.create(name="Org Other", slug="org-sc-other")
+    Subscription.objects.filter(organizer=org_other).delete()
+
+    sub_v1 = Subscription.objects.create(
+        organizer=org1,
+        tier_version=v1,
+        status=SubscriptionStatus.ACTIVE,
+        starts_at=now(),
+    )
+    sub_v2 = Subscription.objects.create(
+        organizer=org2,
+        tier_version=v2,
+        status=SubscriptionStatus.ACTIVE,
+        starts_at=now(),
+    )
+    sub_other = Subscription.objects.create(
+        organizer=org_other,
+        tier_version=v1_other,
+        status=SubscriptionStatus.ACTIVE,
+        starts_at=now(),
+    )
+
+    migrated_count = migrate_tier_subscribers(tier, v3, from_version=v1)
+    assert migrated_count == 1
+
+    sub_v1.refresh_from_db()
+    sub_v2.refresh_from_db()
+    sub_other.refresh_from_db()
+
+    assert sub_v1.tier_version == v3
+    assert sub_v2.tier_version == v2
+    assert sub_other.tier_version == v1_other
+
+
+@pytest.mark.django_db
 def test_tier_detail_view_shows_migrate_checkbox(business_admin_client, sample_tier):
     v1 = sample_tier.versions.first()
     v1.published_at = now()

--- a/tests/test_tier_admin.py
+++ b/tests/test_tier_admin.py
@@ -1,7 +1,16 @@
 import pytest
 from django.urls import reverse
+from django.utils.timezone import now
+from eventyay.base.models import Organizer
 
-from eventyay_business.models import Tier, TierStatus, TierVersion
+from eventyay_business.models import (
+    Subscription,
+    SubscriptionStatus,
+    Tier,
+    TierStatus,
+    TierVersion,
+)
+from eventyay_business.services import migrate_tier_subscribers
 
 
 @pytest.fixture
@@ -77,3 +86,137 @@ def test_tier_new_draft_view(business_admin_client, sample_tier):
     v2 = sample_tier.versions.order_by("-version").first()
     assert v2.version == 2
     assert v2.published_at is None
+
+
+@pytest.mark.django_db
+def test_migrate_tier_subscribers_service():
+    tier = Tier.objects.create(
+        name="Pro", slug="pro-migrate", status=TierStatus.PUBLISHED
+    )
+    v1 = TierVersion.objects.create(tier=tier, version=1, published_at=now())
+    v2 = TierVersion.objects.create(tier=tier, version=2, published_at=now())
+
+    org1 = Organizer.objects.create(name="Org 1", slug="org-1")
+    Subscription.objects.filter(organizer=org1).delete()
+    org2 = Organizer.objects.create(name="Org 2", slug="org-2")
+    Subscription.objects.filter(organizer=org2).delete()
+
+    sub_active = Subscription.objects.create(
+        organizer=org1,
+        tier_version=v1,
+        status=SubscriptionStatus.ACTIVE,
+        starts_at=now(),
+    )
+    sub_canceled = Subscription.objects.create(
+        organizer=org2,
+        tier_version=v1,
+        status=SubscriptionStatus.CANCELED,
+        starts_at=now(),
+    )
+
+    migrated_count = migrate_tier_subscribers(tier, v2)
+    assert migrated_count == 1
+
+    sub_active.refresh_from_db()
+    sub_canceled.refresh_from_db()
+
+    assert sub_active.tier_version == v2
+    assert sub_canceled.tier_version == v1
+
+
+@pytest.mark.django_db
+def test_tier_detail_view_shows_migrate_checkbox(business_admin_client, sample_tier):
+    v1 = sample_tier.versions.first()
+    v1.published_at = now()
+    v1.save()
+    sample_tier.status = TierStatus.PUBLISHED
+    sample_tier.save()
+
+    # Create draft v2
+    TierVersion.objects.create(tier=sample_tier, version=2)
+
+    org = Organizer.objects.create(name="Org Subscriber", slug="org-sub")
+    Subscription.objects.filter(organizer=org).delete()
+    Subscription.objects.create(
+        organizer=org,
+        tier_version=v1,
+        status=SubscriptionStatus.ACTIVE,
+        starts_at=now(),
+    )
+
+    url = reverse(
+        "plugins:eventyay_business:tiers.detail", kwargs={"pk": sample_tier.pk}
+    )
+    response = business_admin_client.get(url)
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert "migrate_subscribers" in content
+    assert "Migrate 1 existing subscriber to v2" in content
+
+
+@pytest.mark.django_db
+def test_tier_publish_view_with_migrate_subscribers(business_admin_client, sample_tier):
+    v1 = sample_tier.versions.first()
+    v1.published_at = now()
+    v1.save()
+    sample_tier.status = TierStatus.PUBLISHED
+    sample_tier.save()
+
+    v2 = TierVersion.objects.create(tier=sample_tier, version=2)
+
+    org = Organizer.objects.create(name="Org To Migrate", slug="org-migrate")
+    Subscription.objects.filter(organizer=org).delete()
+    sub = Subscription.objects.create(
+        organizer=org,
+        tier_version=v1,
+        status=SubscriptionStatus.ACTIVE,
+        starts_at=now(),
+    )
+
+    url = reverse(
+        "plugins:eventyay_business:tiers.publish", kwargs={"pk": sample_tier.pk}
+    )
+    response = business_admin_client.post(
+        url, {"migrate_subscribers": "1"}, follow=True
+    )
+    assert response.status_code == 200
+
+    v2.refresh_from_db()
+    assert v2.published_at is not None
+
+    sub.refresh_from_db()
+    assert sub.tier_version == v2
+
+
+@pytest.mark.django_db
+def test_tier_publish_view_without_migrate_subscribers(
+    business_admin_client, sample_tier
+):
+    v1 = sample_tier.versions.first()
+    v1.published_at = now()
+    v1.save()
+    sample_tier.status = TierStatus.PUBLISHED
+    sample_tier.save()
+
+    v2 = TierVersion.objects.create(tier=sample_tier, version=2)
+
+    org = Organizer.objects.create(name="Org Keep V1", slug="org-keep-v1")
+    Subscription.objects.filter(organizer=org).delete()
+    sub = Subscription.objects.create(
+        organizer=org,
+        tier_version=v1,
+        status=SubscriptionStatus.ACTIVE,
+        starts_at=now(),
+    )
+
+    url = reverse(
+        "plugins:eventyay_business:tiers.publish", kwargs={"pk": sample_tier.pk}
+    )
+    response = business_admin_client.post(url, {}, follow=True)
+    assert response.status_code == 200
+
+    v2.refresh_from_db()
+    assert v2.published_at is not None
+
+    sub.refresh_from_db()
+    assert sub.tier_version == v1


### PR DESCRIPTION

<img width="5088" height="3344" alt="image" src="https://github.com/user-attachments/assets/c6399063-0696-4722-bed1-9b8ed25f9845" />


## Description
When publishing a new tier version (e.g. from v1 to v2), admins previously had to manually reassign or update existing organizers subscribed to the tier.

This PR introduces an automated migration option during the publishing flow:
1. **Service Helper (`migrate_tier_subscribers`)**:
   - Updates active and pending subscriptions associated with the tier to the new target version atomically.
   - Canceled, expired, or non-target subscriptions are unaffected.
2. **UI Integration**:
   - In `TierDetailView`, detects if there is a previously published version of the tier and counts how many active/pending subscribers exist.
   - In the Publish Draft form of `detail.html`, adds a checkbox (checked by default): `Migrate X existing subscriber(s) to v<N>`.
3. **Publishing Handler**:
   - In `TierPublishView`, processes the `migrate_subscribers` flag and informs the admin via success message of the number of migrated subscribers.
4. **Automated Tests**:
   - Unit tests covering `migrate_tier_subscribers` service (active migrated, canceled preserved).
   - View test confirming checkbox and count render in the template.
   - View tests verifying publishing with and without `migrate_subscribers` checkbox.

Closes #49

## Summary by Sourcery

Enable administrators to migrate eligible existing tier subscribers to a new version during publication.

New Features:
- Add an optional publishing-flow action to migrate active and pending subscribers from previous tier versions to the newly published version.
- Show administrators the eligible subscriber count and migration option when publishing a new tier draft.
- Report the number of migrated subscribers after publishing.

Enhancements:
- Keep canceled, expired, and unrelated subscriptions on their existing tier versions while supporting scoped migrations.

Tests:
- Add service and view coverage for subscriber migration, validation, UI rendering, and publishing with or without migration enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an option when publishing a new tier version to migrate existing active and pending subscribers from a previous version.
  - The publishing form displays a subscriber count and confirmation checkbox when migration is available.
  - Publishing without selecting migration continues without moving subscribers.
  - Success messages now report how many subscribers were migrated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## Stack

```
dev
└── #50  feat: option to migrate existing subscribers when publishing a new tier version  ← you are here
    └── #52  feat: add per-version detail view for tier version history
```