### PR TITLE
feat: add per-version detail view for tier version history

### DIFF
--- a/eventyay_business/templates/eventyay_business/tiers/detail.html
+++ b/eventyay_business/templates/eventyay_business/tiers/detail.html
@@ -167,7 +167,8 @@
                 </div>
                 <div class="list-group">
                     {% for version in tier.versions.all %}
-                        <div class="list-group-item">
+                        <a href="{% url 'plugins:eventyay_business:tiers.version_detail' pk=tier.pk version_pk=version.pk %}"
+                           class="list-group-item">
                             <h4 class="list-group-item-heading">
                                 v{{ version.version }}
                                 {% if version.published_at %}
@@ -179,7 +180,7 @@
                             <p class="list-group-item-text">
                                 {{ version.prices.count }} {% trans "prices" %}, {{ version.entitlements.count }} {% trans "entitlements" %}
                             </p>
-                        </div>
+                        </a>
                     {% endfor %}
                 </div>
             </div>

--- a/eventyay_business/templates/eventyay_business/tiers/version_detail.html
+++ b/eventyay_business/templates/eventyay_business/tiers/version_detail.html
@@ -124,7 +124,7 @@
                 <div class="panel-body">
                     <p>
                         <strong>{% trans "Active / Pending:" %}</strong>
-                        {{ version.subscriptions.count }}
+                        {{ active_subscriber_count }}
                     </p>
                     <p class="text-muted small">
                         {% trans "Count of subscriptions currently on this version." %}

--- a/eventyay_business/templates/eventyay_business/tiers/version_detail.html
+++ b/eventyay_business/templates/eventyay_business/tiers/version_detail.html
@@ -1,0 +1,136 @@
+{% extends "pretixcontrol/admin/base.html" %}
+{% load i18n %}
+
+{% block title %}
+    {{ tier.name }} — {% trans "Version" %} v{{ version.version }}
+{% endblock %}
+
+{% block content %}
+    <h1>
+        {{ tier.name }}
+        <small>
+            {% trans "Version" %} v{{ version.version }}
+            {% if version.published_at %}
+                <span class="label label-success">{% trans "Published" %}</span>
+            {% else %}
+                <span class="label label-warning">{% trans "Draft" %}</span>
+            {% endif %}
+        </small>
+    </h1>
+
+    <p>
+        <a href="{% url 'plugins:eventyay_business:tiers.detail' pk=tier.pk %}"
+           class="btn btn-default btn-sm">
+            <i class="fa fa-fw fa-arrow-left"></i> {% trans "Back to Tier" %}
+        </a>
+    </p>
+
+    <div class="row">
+        <div class="col-md-8">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">{% trans "Version Info" %}</h3>
+                </div>
+                <div class="panel-body">
+                    <dl class="dl-horizontal">
+                        <dt>{% trans "Version" %}</dt>
+                        <dd>v{{ version.version }}</dd>
+                        <dt>{% trans "Status" %}</dt>
+                        <dd>
+                            {% if version.published_at %}
+                                {% trans "Published" %} {{ version.published_at|date:"SHORT_DATETIME_FORMAT" }}
+                            {% else %}
+                                {% trans "Draft (unpublished)" %}
+                            {% endif %}
+                        </dd>
+                        <dt>{% trans "Created by" %}</dt>
+                        <dd>{{ version.created_by|default:"-" }}</dd>
+                    </dl>
+                </div>
+            </div>
+
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">{% trans "Prices" %}</h3>
+                </div>
+                <div class="panel-body">
+                    {% if version.prices.all %}
+                        <table class="table table-condensed">
+                            <thead>
+                                <tr>
+                                    <th>{% trans "Interval" %}</th>
+                                    <th>{% trans "Amount" %}</th>
+                                    <th>{% trans "Active" %}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for price in version.prices.all %}
+                                <tr>
+                                    <td>{{ price.get_billing_interval_display }}</td>
+                                    <td>{{ price.currency }} {{ price.amount }}</td>
+                                    <td>{{ price.active|yesno:"Yes,No" }}</td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    {% else %}
+                        <p class="text-muted">{% trans "No prices defined for this version." %}</p>
+                    {% endif %}
+                </div>
+            </div>
+
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">{% trans "Entitlements" %}</h3>
+                </div>
+                <div class="panel-body">
+                    {% if version.entitlements.all %}
+                        <table class="table table-condensed">
+                            <thead>
+                                <tr>
+                                    <th>{% trans "Capability" %}</th>
+                                    <th>{% trans "Value" %}</th>
+                                    <th>{% trans "Overage Allowed" %}</th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                {% for ent in version.entitlements.all %}
+                                <tr>
+                                    <td>{{ ent.capability }}</td>
+                                    <td>{{ ent.value|default:"-" }} {{ ent.unit }}</td>
+                                    <td>
+                                        {% if ent.overage_allowed %}
+                                            {% trans "Yes" %} ({{ ent.currency|default:"" }} {{ ent.overage_price|default:"0" }} / {{ ent.overage_block_size|default:"1" }})
+                                        {% else %}
+                                            {% trans "No" %}
+                                        {% endif %}
+                                    </td>
+                                </tr>
+                                {% endfor %}
+                            </tbody>
+                        </table>
+                    {% else %}
+                        <p class="text-muted">{% trans "No entitlements defined for this version." %}</p>
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+
+        <div class="col-md-4">
+            <div class="panel panel-default">
+                <div class="panel-heading">
+                    <h3 class="panel-title">{% trans "Subscribers" %}</h3>
+                </div>
+                <div class="panel-body">
+                    <p>
+                        <strong>{% trans "Active / Pending:" %}</strong>
+                        {{ version.subscriptions.count }}
+                    </p>
+                    <p class="text-muted small">
+                        {% trans "Count of subscriptions currently on this version." %}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/eventyay_business/urls.py
+++ b/eventyay_business/urls.py
@@ -18,6 +18,11 @@ urlpatterns = [
         name="tiers.detail",
     ),
     path(
+        "admin/global/business/tiers/<int:pk>/versions/<int:version_pk>/",
+        views.TierVersionDetailView.as_view(),
+        name="tiers.version_detail",
+    ),
+    path(
         "admin/global/business/tiers/<int:pk>/edit/",
         views.TierUpdateView.as_view(),
         name="tiers.edit",

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -186,6 +186,10 @@ class TierVersionDetailView(AdministratorPermissionRequiredMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["tier"] = self.object.tier
+        context["active_subscriber_count"] = Subscription.objects.filter(
+            tier_version=self.object,
+            status__in=[SubscriptionStatus.ACTIVE, SubscriptionStatus.PENDING],
+        ).count()
         return context
 
 

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -310,8 +310,6 @@ class SubscriptionUpdateView(AdministratorPermissionRequiredMixin, UpdateView):
         return reverse("plugins:eventyay_business:subscriptions.list")
 
 
-
-
 class OrganizerPlanView(
     OrganizerPermissionRequiredMixin, OrganizerDetailViewMixin, TemplateView
 ):

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -8,11 +8,19 @@ from django.views.generic import (
     CreateView,
     DetailView,
     ListView,
+    TemplateView,
     UpdateView,
     View,
 )
-from eventyay.control.permissions import AdministratorPermissionRequiredMixin
+from eventyay.control.permissions import (
+    AdministratorPermissionRequiredMixin,
+    OrganizerPermissionRequiredMixin,
+)
+from eventyay.control.views.organizer_views.organizer_detail_view_mixin import (
+    OrganizerDetailViewMixin,
+)
 
+from .capabilities import get_all_capabilities
 from .forms import (
     SubscriptionAdminForm,
     TierEntitlementFormSet,
@@ -163,6 +171,24 @@ class TierDetailView(AdministratorPermissionRequiredMixin, DetailView):
         return context
 
 
+class TierVersionDetailView(AdministratorPermissionRequiredMixin, DetailView):
+    """Show all details for a specific historical TierVersion."""
+
+    model = TierVersion
+    template_name = "eventyay_business/tiers/version_detail.html"
+    context_object_name = "version"
+    pk_url_kwarg = "version_pk"
+
+    def get_object(self, queryset=None):
+        tier = get_object_or_404(Tier, pk=self.kwargs["pk"])
+        return get_object_or_404(TierVersion, pk=self.kwargs["version_pk"], tier=tier)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["tier"] = self.object.tier
+        return context
+
+
 class TierNewDraftView(AdministratorPermissionRequiredMixin, View):
     """Creates a new DRAFT TierVersion from the latest PUBLISHED version."""
 
@@ -284,13 +310,6 @@ class SubscriptionUpdateView(AdministratorPermissionRequiredMixin, UpdateView):
         return reverse("plugins:eventyay_business:subscriptions.list")
 
 
-from django.views.generic import TemplateView
-from eventyay.control.permissions import OrganizerPermissionRequiredMixin
-from eventyay.control.views.organizer_views.organizer_detail_view_mixin import (
-    OrganizerDetailViewMixin,
-)
-
-from .capabilities import get_all_capabilities
 
 
 class OrganizerPlanView(

--- a/tests/test_tier_admin.py
+++ b/tests/test_tier_admin.py
@@ -298,3 +298,47 @@ def test_tier_publish_view_without_migrate_subscribers(
 
     sub.refresh_from_db()
     assert sub.tier_version == v1
+
+
+@pytest.mark.django_db
+def test_tier_version_detail_view(business_admin_client, sample_tier):
+    version = sample_tier.versions.first()
+    url = reverse(
+        "plugins:eventyay_business:tiers.version_detail",
+        kwargs={"pk": sample_tier.pk, "version_pk": version.pk},
+    )
+    response = business_admin_client.get(url)
+    assert response.status_code == 200
+    content = response.content.decode()
+    assert f"v{version.version}" in content
+    assert sample_tier.name in content
+
+
+@pytest.mark.django_db
+def test_tier_version_detail_view_wrong_tier(business_admin_client, sample_tier):
+    other_tier = Tier.objects.create(
+        name="Other", slug="other-vd", status=TierStatus.DRAFT
+    )
+    version = sample_tier.versions.first()
+    url = reverse(
+        "plugins:eventyay_business:tiers.version_detail",
+        kwargs={"pk": other_tier.pk, "version_pk": version.pk},
+    )
+    response = business_admin_client.get(url)
+    assert response.status_code == 404
+
+
+@pytest.mark.django_db
+def test_tier_detail_version_history_links(business_admin_client, sample_tier):
+    """Version history items in detail page should link to tiers.version_detail."""
+    version = sample_tier.versions.first()
+    expected_url = reverse(
+        "plugins:eventyay_business:tiers.version_detail",
+        kwargs={"pk": sample_tier.pk, "version_pk": version.pk},
+    )
+    url = reverse(
+        "plugins:eventyay_business:tiers.detail", kwargs={"pk": sample_tier.pk}
+    )
+    response = business_admin_client.get(url)
+    assert response.status_code == 200
+    assert expected_url in response.content.decode()


### PR DESCRIPTION
<img width="5088" height="3344" alt="2026-09-10_12-35-21" src="https://github.com/user-attachments/assets/7e8d099b-080b-4b65-aa86-99a214ed0460" />



Closes #51

> **Stacked PR** — this is stacked on top of #50. Merge #50 first, then this PR will rebase cleanly onto `dev`.

## Summary

Previously, the **Version History** panel on the Tier Detail page listed all versions as plain, non-clickable items. Admins had no way to inspect prices, entitlements, or subscriber counts for historical versions.

This PR adds a dedicated per-version detail page and links every version history item to it.

## Changes

| File | Change |
|---|---|
| `eventyay_business/views.py` | Added `TierVersionDetailView`; moved all late organizer imports to file top; applied black |
| `eventyay_business/urls.py` | New route `tiers/<pk>/versions/<version_pk>/` → `tiers.version_detail` |
| `templates/tiers/version_detail.html` | New page: version info, prices table, entitlements table, subscriber count, back-link |
| `templates/tiers/detail.html` | Version history items are now `<a>` links instead of non-interactive `<div>`s |
| `tests/test_tier_admin.py` | 3 new tests: valid detail (200), wrong-tier (404), detail page has correct links |

## Test Results

```
12 passed in 48.56s
```

## Stack

```
dev
└── #50  feat: option to migrate existing subscribers when publishing a new tier version
    └── #52  feat: add per-version detail view for tier version history  ← you are here
```

## Summary by Sourcery

Enable administrators to inspect historical tier versions directly from the tier version history.

New Features:
- Add an administrator page for inspecting individual tier versions, including status, pricing, entitlements, and subscriber counts.

Enhancements:
- Make tier version history entries navigable and constrain version detail access to the selected tier.

Tests:
- Add coverage for valid version details, cross-tier access returning 404, and version history links.