### PR TITLE
feat: implement tier-specific paid-order calculations

### DIFF
--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -18,11 +18,13 @@ try:
         entitlement_check,
         entitlement_usage_recorded,
         register_entitlements,
+        order_paid,
     )
 except ImportError:
     register_entitlements = None
     entitlement_check = None
     entitlement_usage_recorded = None
+    order_paid = None
 
 
 if nav_global:
@@ -260,7 +262,7 @@ if entitlement_usage_recorded:
         idempotency_key: str,
         event=None,
         metadata=None,
-        **kwargs
+        **kwargs,
     ):
         from .services import record_usage
 
@@ -278,4 +280,86 @@ if entitlement_usage_recorded:
             source_id=source_id,
             idempotency_key=idempotency_key,
             metadata=metadata,
+        )
+
+
+if order_paid:
+
+    @receiver(order_paid, dispatch_uid="business_order_paid_fee")
+    def record_platform_fee_on_order_paid(sender, order, **kwargs):
+        from .models import Subscription, UsageRecord
+        from decimal import Decimal
+        from django.utils.timezone import now
+
+        event = sender
+        organizer = event.organizer
+
+        current_time = now()
+        sub = (
+            Subscription.objects.filter(
+                organizer=organizer,
+                status="active",
+                starts_at__lte=current_time,
+            )
+            .exclude(ends_at__lt=current_time)
+            .select_related("tier_version")
+            .first()
+        )
+
+        if not sub or not sub.tier_version:
+            return
+
+        from .capabilities import get_capability
+        
+        cap_def = get_capability("commerce.platform_fee_percent")
+        if not cap_def:
+            return
+
+        ent = sub.tier_version.entitlements.filter(
+            capability="commerce.platform_fee_percent"
+        ).first()
+
+        if ent:
+            fee_percent = ent.get_typed_value()
+        else:
+            fee_percent = cap_def.default_value
+
+        if not fee_percent or fee_percent <= Decimal("0.0"):
+            return
+
+        # Calculate fee base: sum of all active positions (price - tax)
+        # Excludes shipping, payment fees (which are OrderFee objects)
+        fee_base = Decimal("0.0")
+        # In Eventyay, order.positions is the default manager that excludes canceled positions
+        for pos in order.positions.all():
+            # some old data might have None for tax_value, default to 0
+            tax = pos.tax_value or Decimal("0.0")
+            fee_base += pos.price - tax
+
+        if fee_base <= Decimal("0.0"):
+            return
+
+        fee_amount = (fee_base * fee_percent / Decimal("100.0")).quantize(
+            Decimal("0.01")
+        )
+
+        if fee_amount <= Decimal("0.0"):
+            return
+
+        UsageRecord.objects.create(
+            organizer=organizer,
+            event=event,
+            capability="commerce.platform_fee_percent",
+            quantity=fee_amount,
+            unit=event.currency,
+            source_type="order",
+            source_id=order.code,
+            idempotency_key=f"order_{order.code}_platform_fee",
+            occurred_at=current_time,
+            metadata={
+                "fee_base": str(fee_base),
+                "fee_percent": str(fee_percent),
+                "order_total": str(order.total),
+                "currency": event.currency,
+            },
         )

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -1,6 +1,10 @@
+import logging
+from django.db import IntegrityError
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
+
+logger = logging.getLogger(__name__)
 
 try:
     from eventyay.control.signals import nav_global, nav_organizer
@@ -295,14 +299,45 @@ if order_paid:
         event = sender
         organizer = event.organizer
 
-        current_time = now()
+        import datetime
+
+        payment_date = kwargs.get("payment_date")
+        if not isinstance(payment_date, (datetime.date, datetime.datetime)):
+            payment_date = None
+
+        if not payment_date:
+            payment = kwargs.get("payment")
+            cand = getattr(payment, "payment_date", None)
+            if isinstance(cand, (datetime.date, datetime.datetime)):
+                payment_date = cand
+
+        if not payment_date and hasattr(order, "payments"):
+            try:
+                confirmed_payment = (
+                    order.payments.filter(state="confirmed")
+                    .order_by("-payment_date")
+                    .first()
+                )
+                cand = getattr(confirmed_payment, "payment_date", None)
+                if isinstance(cand, (datetime.date, datetime.datetime)):
+                    payment_date = cand
+            except Exception:
+                pass
+
+        if not payment_date:
+            cand = getattr(order, "datetime", None)
+            if isinstance(cand, (datetime.date, datetime.datetime)):
+                payment_date = cand
+            else:
+                payment_date = now()
+
         sub = (
             Subscription.objects.filter(
                 organizer=organizer,
                 status="active",
-                starts_at__lte=current_time,
+                starts_at__lte=payment_date,
             )
-            .exclude(ends_at__lt=current_time)
+            .exclude(ends_at__lt=payment_date)
             .select_related("tier_version")
             .first()
         )
@@ -361,33 +396,45 @@ if order_paid:
             rates_dict = gs.settings.get("ecb_rates_dict", as_type=dict)
             rates_date = gs.settings.get("ecb_rates_date")
 
-            if (
+            if not (
                 rates_dict
                 and event.currency in rates_dict
                 and sub.currency in rates_dict
             ):
-                from decimal import ROUND_HALF_UP
+                logger.warning(
+                    "Exchange rate unavailable for converting platform fee from %s to %s for order %s. Stopping fee persistence.",
+                    event.currency,
+                    sub.currency,
+                    order.code,
+                )
+                return
 
-                rate = (
-                    Decimal(rates_dict[sub.currency])
-                    / Decimal(rates_dict[event.currency])
-                ).quantize(Decimal("0.0001"), ROUND_HALF_UP)
+            from decimal import ROUND_HALF_UP
 
-                converted_fee = (fee_amount * rate).quantize(Decimal("0.01"))
-                metadata["billing_currency"] = sub.currency
-                metadata["exchange_rate"] = str(rate)
-                metadata["exchange_rate_date"] = str(rates_date)
-                metadata["billing_currency_fee_amount"] = str(converted_fee)
+            rate = (
+                Decimal(rates_dict[sub.currency]) / Decimal(rates_dict[event.currency])
+            ).quantize(Decimal("0.0001"), ROUND_HALF_UP)
 
-        UsageRecord.objects.create(
-            organizer=organizer,
-            event=event,
-            capability="commerce.platform_fee_percent",
-            quantity=fee_amount,
-            unit=event.currency,
-            source_type="order",
-            source_id=order.code,
-            idempotency_key=f"order_{order.code}_platform_fee",
-            occurred_at=current_time,
-            metadata=metadata,
-        )
+            converted_fee = (fee_amount * rate).quantize(Decimal("0.01"))
+            metadata["billing_currency"] = sub.currency
+            metadata["exchange_rate"] = str(rate)
+            metadata["exchange_rate_date"] = str(rates_date)
+            metadata["billing_currency_fee_amount"] = str(converted_fee)
+
+        try:
+            UsageRecord.objects.get_or_create(
+                organizer=organizer,
+                idempotency_key=f"order_{order.code}_platform_fee",
+                defaults={
+                    "event": event,
+                    "capability": "commerce.platform_fee_percent",
+                    "quantity": fee_amount,
+                    "unit": event.currency,
+                    "source_type": "order",
+                    "source_id": order.code,
+                    "occurred_at": payment_date,
+                    "metadata": metadata,
+                },
+            )
+        except IntegrityError:
+            pass

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -17,8 +17,8 @@ try:
     from eventyay.base.signals import (
         entitlement_check,
         entitlement_usage_recorded,
-        register_entitlements,
         order_paid,
+        register_entitlements,
     )
 except ImportError:
     register_entitlements = None
@@ -287,9 +287,10 @@ if order_paid:
 
     @receiver(order_paid, dispatch_uid="business_order_paid_fee")
     def record_platform_fee_on_order_paid(sender, order, **kwargs):
-        from .models import Subscription, UsageRecord
         from decimal import Decimal
         from django.utils.timezone import now
+
+        from .models import Subscription, UsageRecord
 
         event = sender
         organizer = event.organizer
@@ -310,7 +311,7 @@ if order_paid:
             return
 
         from .capabilities import get_capability
-        
+
         cap_def = get_capability("commerce.platform_fee_percent")
         if not cap_def:
             return

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -347,6 +347,31 @@ if order_paid:
         if fee_amount <= Decimal("0.0"):
             return
 
+        metadata = {
+            "fee_base": str(fee_base),
+            "fee_percent": str(fee_percent),
+            "order_total": str(order.total),
+            "currency": event.currency,
+        }
+
+        if sub.currency and sub.currency != event.currency:
+            from eventyay.base.settings import GlobalSettingsObject
+            gs = GlobalSettingsObject()
+            rates_dict = gs.settings.get("ecb_rates_dict", as_type=dict)
+            rates_date = gs.settings.get("ecb_rates_date")
+            
+            if rates_dict and event.currency in rates_dict and sub.currency in rates_dict:
+                from decimal import ROUND_HALF_UP
+                rate = (
+                    Decimal(rates_dict[sub.currency]) / Decimal(rates_dict[event.currency])
+                ).quantize(Decimal("0.0001"), ROUND_HALF_UP)
+                
+                converted_fee = (fee_amount * rate).quantize(Decimal("0.01"))
+                metadata["billing_currency"] = sub.currency
+                metadata["exchange_rate"] = str(rate)
+                metadata["exchange_rate_date"] = str(rates_date)
+                metadata["billing_currency_fee_amount"] = str(converted_fee)
+
         UsageRecord.objects.create(
             organizer=organizer,
             event=event,
@@ -357,10 +382,5 @@ if order_paid:
             source_id=order.code,
             idempotency_key=f"order_{order.code}_platform_fee",
             occurred_at=current_time,
-            metadata={
-                "fee_base": str(fee_base),
-                "fee_percent": str(fee_percent),
-                "order_total": str(order.total),
-                "currency": event.currency,
-            },
+            metadata=metadata,
         )

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -1,3 +1,4 @@
+from django.db.models import Sum
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -193,8 +194,6 @@ if entitlement_check and EntitlementDecision:
         if cap_def.value_type == CapabilityValueType.INTEGER:
             total_quantity = quantity
             if capability.endswith(".monthly"):
-                from django.db.models import Sum
-
                 from .models import UsageRecord
 
                 usage_agg = UsageRecord.objects.filter(

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -191,11 +191,27 @@ if entitlement_check and EntitlementDecision:
                 )
 
         if cap_def.value_type == CapabilityValueType.INTEGER:
-            if value is not None and quantity > value:
+            total_quantity = quantity
+            if capability.endswith('.monthly'):
+                from django.db.models import Sum
+                from .models import UsageRecord
+                
+                usage_agg = UsageRecord.objects.filter(
+                    organizer=organizer,
+                    capability=capability,
+                    occurred_at__year=current_time.year,
+                    occurred_at__month=current_time.month,
+                ).aggregate(total=Sum('quantity'))
+                
+                past_usage = usage_agg['total'] or 0
+                total_quantity = quantity + int(past_usage)
+
+            if value is not None and total_quantity > value:
                 return EntitlementDecision(
                     allowed=False,
                     reason_code="tier_limit_exceeded",
                     limit=value,
+                    used=past_usage if capability.endswith('.monthly') else None,
                     message="You have reached the maximum limit for this feature on your current plan.",
                 )
             return EntitlementDecision(allowed=True, limit=value)

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -356,16 +356,23 @@ if order_paid:
 
         if sub.currency and sub.currency != event.currency:
             from eventyay.base.settings import GlobalSettingsObject
+
             gs = GlobalSettingsObject()
             rates_dict = gs.settings.get("ecb_rates_dict", as_type=dict)
             rates_date = gs.settings.get("ecb_rates_date")
-            
-            if rates_dict and event.currency in rates_dict and sub.currency in rates_dict:
+
+            if (
+                rates_dict
+                and event.currency in rates_dict
+                and sub.currency in rates_dict
+            ):
                 from decimal import ROUND_HALF_UP
+
                 rate = (
-                    Decimal(rates_dict[sub.currency]) / Decimal(rates_dict[event.currency])
+                    Decimal(rates_dict[sub.currency])
+                    / Decimal(rates_dict[event.currency])
                 ).quantize(Decimal("0.0001"), ROUND_HALF_UP)
-                
+
                 converted_fee = (fee_amount * rate).quantize(Decimal("0.01"))
                 metadata["billing_currency"] = sub.currency
                 metadata["exchange_rate"] = str(rate)

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -192,18 +192,19 @@ if entitlement_check and EntitlementDecision:
 
         if cap_def.value_type == CapabilityValueType.INTEGER:
             total_quantity = quantity
-            if capability.endswith('.monthly'):
+            if capability.endswith(".monthly"):
                 from django.db.models import Sum
+
                 from .models import UsageRecord
-                
+
                 usage_agg = UsageRecord.objects.filter(
                     organizer=organizer,
                     capability=capability,
                     occurred_at__year=current_time.year,
                     occurred_at__month=current_time.month,
-                ).aggregate(total=Sum('quantity'))
-                
-                past_usage = usage_agg['total'] or 0
+                ).aggregate(total=Sum("quantity"))
+
+                past_usage = usage_agg["total"] or 0
                 total_quantity = quantity + int(past_usage)
 
             if value is not None and total_quantity > value:
@@ -211,7 +212,7 @@ if entitlement_check and EntitlementDecision:
                     allowed=False,
                     reason_code="tier_limit_exceeded",
                     limit=value,
-                    used=past_usage if capability.endswith('.monthly') else None,
+                    used=past_usage if capability.endswith(".monthly") else None,
                     message="You have reached the maximum limit for this feature on your current plan.",
                 )
             return EntitlementDecision(allowed=True, limit=value)

--- a/tests/test_platform_fee.py
+++ b/tests/test_platform_fee.py
@@ -157,3 +157,109 @@ def test_platform_fee_currency_conversion(organizer_with_fee_tier):
     assert record.metadata["exchange_rate"] == "0.9091"
     assert record.metadata["exchange_rate_date"] == "2026-09-11"
     assert record.metadata["billing_currency_fee_amount"] == "5.00"
+
+
+@pytest.mark.django_db
+def test_platform_fee_idempotent_repeated_delivery(organizer_with_fee_tier):
+    from eventyay.base.models import Event
+
+    event = Event.objects.create(
+        organizer=organizer_with_fee_tier,
+        name="Test Event Repeat",
+        slug="test-event-repeat",
+        currency="USD",
+        date_from=now(),
+    )
+
+    order = MagicMock()
+    order.code = "REPEAT123"
+    order.total = Decimal("100.00")
+    pos = MagicMock(price=Decimal("100.00"), tax_value=Decimal("0.00"))
+    order.positions.all.return_value = [pos]
+
+    # Invoke twice to test idempotent processing
+    record_platform_fee_on_order_paid(sender=event, order=order)
+    record_platform_fee_on_order_paid(sender=event, order=order)
+
+    assert (
+        UsageRecord.objects.filter(
+            idempotency_key="order_REPEAT123_platform_fee"
+        ).count()
+        == 1
+    )
+
+
+@pytest.mark.django_db
+def test_platform_fee_currency_conversion_missing_rates_stops_persistence(
+    organizer_with_fee_tier,
+):
+    from eventyay.base.models import Event
+    from eventyay.base.settings import GlobalSettingsObject
+
+    gs = GlobalSettingsObject()
+    gs.settings.ecb_rates_date = "2026-09-11"
+    # Event is JPY, Subscription is EUR, but JPY is missing from rates
+    gs.settings.ecb_rates_dict = {"EUR": "1.0000", "USD": "1.1000"}
+
+    sub = Subscription.objects.get(organizer=organizer_with_fee_tier)
+    sub.currency = "EUR"
+    sub.save()
+
+    event = Event.objects.create(
+        organizer=organizer_with_fee_tier,
+        name="Test Event JPY",
+        slug="test-event-jpy",
+        currency="JPY",
+        date_from=now(),
+    )
+
+    order = MagicMock()
+    order.code = "MISSINGRATE"
+    order.total = Decimal("10000.00")
+    pos = MagicMock(price=Decimal("10000.00"), tax_value=Decimal("0.00"))
+    order.positions.all.return_value = [pos]
+
+    record_platform_fee_on_order_paid(sender=event, order=order)
+
+    # Persistence must stop when exchange rate is unavailable
+    assert (
+        UsageRecord.objects.filter(
+            idempotency_key="order_MISSINGRATE_platform_fee"
+        ).count()
+        == 0
+    )
+
+
+@pytest.mark.django_db
+def test_platform_fee_uses_payment_timestamp(organizer_with_fee_tier):
+    import datetime
+    from django.utils.timezone import make_aware
+    from eventyay.base.models import Event
+
+    event = Event.objects.create(
+        organizer=organizer_with_fee_tier,
+        name="Test Event Payment Date",
+        slug="test-event-payment-date",
+        currency="USD",
+        date_from=now(),
+    )
+
+    confirmed_date = make_aware(datetime.datetime(2026, 8, 15, 10, 0, 0))
+
+    sub = Subscription.objects.get(organizer=organizer_with_fee_tier)
+    sub.starts_at = confirmed_date - datetime.timedelta(days=1)
+    sub.save()
+
+    order = MagicMock()
+    order.code = "PAYDATE"
+    order.total = Decimal("100.00")
+    pos = MagicMock(price=Decimal("100.00"), tax_value=Decimal("0.00"))
+    order.positions.all.return_value = [pos]
+
+    payment = MagicMock()
+    payment.payment_date = confirmed_date
+
+    record_platform_fee_on_order_paid(sender=event, order=order, payment=payment)
+
+    record = UsageRecord.objects.get(idempotency_key="order_PAYDATE_platform_fee")
+    assert record.occurred_at == confirmed_date

--- a/tests/test_platform_fee.py
+++ b/tests/test_platform_fee.py
@@ -107,3 +107,53 @@ def test_platform_fee_zero_percent(organizer_with_fee_tier):
 
     # Should not create a usage record for 0% fee
     assert UsageRecord.objects.count() == 0
+
+
+@pytest.mark.django_db
+def test_platform_fee_currency_conversion(organizer_with_fee_tier):
+    from eventyay.base.models import Event
+    from eventyay.base.settings import GlobalSettingsObject
+
+    gs = GlobalSettingsObject()
+    gs.settings.ecb_rates_date = "2026-09-11"
+    # Event is USD, Subscription is EUR
+    # 1 EUR = 1.10 USD
+    gs.settings.ecb_rates_dict = {"EUR": "1.0000", "USD": "1.1000"}
+
+    sub = Subscription.objects.get(organizer=organizer_with_fee_tier)
+    sub.currency = "EUR"
+    sub.save()
+
+    event = Event.objects.create(
+        organizer=organizer_with_fee_tier,
+        name="Test Event 3",
+        slug="test-event-3",
+        currency="USD",
+        date_from=now(),
+    )
+
+    order = MagicMock()
+    order.code = "CONVERT"
+    order.total = Decimal("110.00")
+
+    pos1 = MagicMock()
+    pos1.price = Decimal("110.00")
+    pos1.tax_value = Decimal("0.00")
+
+    order.positions.all.return_value = [pos1]
+
+    record_platform_fee_on_order_paid(sender=event, order=order)
+
+    assert UsageRecord.objects.count() == 1
+    record = UsageRecord.objects.first()
+
+    assert record.unit == "USD"
+    # Base = 110. Fee = 110 * 5% = 5.50 USD.
+    assert record.quantity == Decimal("5.50")
+
+    # 1 USD = 1/1.10 EUR = 0.9091 EUR
+    # Converted fee = 5.50 * 0.9091 = 5.00 EUR
+    assert record.metadata["billing_currency"] == "EUR"
+    assert record.metadata["exchange_rate"] == "0.9091"
+    assert record.metadata["exchange_rate_date"] == "2026-09-11"
+    assert record.metadata["billing_currency_fee_amount"] == "5.00"

--- a/tests/test_platform_fee.py
+++ b/tests/test_platform_fee.py
@@ -1,13 +1,13 @@
 import pytest
 from decimal import Decimal
-from unittest.mock import MagicMock
 from django.utils.timezone import now
+from unittest.mock import MagicMock
 
 from eventyay_business.models import (
     Subscription,
     Tier,
-    TierVersion,
     TierEntitlement,
+    TierVersion,
     UsageRecord,
 )
 from eventyay_business.signals import record_platform_fee_on_order_paid

--- a/tests/test_platform_fee.py
+++ b/tests/test_platform_fee.py
@@ -1,0 +1,109 @@
+import pytest
+from decimal import Decimal
+from unittest.mock import MagicMock
+from django.utils.timezone import now
+
+from eventyay_business.models import (
+    Subscription,
+    Tier,
+    TierVersion,
+    TierEntitlement,
+    UsageRecord,
+)
+from eventyay_business.signals import record_platform_fee_on_order_paid
+
+
+@pytest.fixture
+def organizer_with_fee_tier(db):
+    from eventyay.base.models import Organizer
+
+    org = Organizer.objects.create(name="Fee Org", slug="fee-org")
+
+    tier = Tier.objects.create(slug="paid", name="Paid Tier")
+    version = TierVersion.objects.create(tier=tier, version=1, published_at=now())
+
+    TierEntitlement.objects.create(
+        tier_version=version, capability="commerce.platform_fee_percent", value="5.0"
+    )
+
+    sub = Subscription.objects.get(organizer=org)
+    sub.tier_version = version
+    sub.save()
+
+    return org
+
+
+@pytest.mark.django_db
+def test_platform_fee_calculation(organizer_with_fee_tier):
+    from eventyay.base.models import Event
+
+    event = Event.objects.create(
+        organizer=organizer_with_fee_tier,
+        name="Test Event",
+        slug="test-event",
+        currency="USD",
+        date_from=now(),
+    )
+
+    order = MagicMock()
+    order.code = "ABCXYZ"
+    order.total = Decimal("120.00")
+
+    pos1 = MagicMock()
+    pos1.price = Decimal("100.00")
+    pos1.tax_value = Decimal("10.00")  # net = 90
+
+    pos2 = MagicMock()
+    pos2.price = Decimal("20.00")
+    pos2.tax_value = Decimal("0.00")  # net = 20
+
+    order.positions.all.return_value = [pos1, pos2]
+
+    record_platform_fee_on_order_paid(sender=event, order=order)
+
+    assert UsageRecord.objects.count() == 1
+    record = UsageRecord.objects.first()
+
+    assert record.organizer == organizer_with_fee_tier
+    assert record.event == event
+    assert record.capability == "commerce.platform_fee_percent"
+    assert record.unit == "USD"
+    assert record.source_type == "order"
+    assert record.source_id == "ABCXYZ"
+
+    # Base = 90 + 20 = 110
+    # Fee = 110 * 5.0% = 5.50
+    assert record.quantity == Decimal("5.50")
+    assert record.metadata["fee_base"] == "110.00"
+    assert record.metadata["fee_percent"] == "5.0"
+    assert record.metadata["order_total"] == "120.00"
+
+
+@pytest.mark.django_db
+def test_platform_fee_zero_percent(organizer_with_fee_tier):
+    # Update fee to 0%
+    sub = Subscription.objects.get(organizer=organizer_with_fee_tier)
+    ent = sub.tier_version.entitlements.first()
+    ent.value = "0.0"
+    ent.save()
+
+    from eventyay.base.models import Event
+
+    event = Event.objects.create(
+        organizer=organizer_with_fee_tier,
+        name="Test Event 2",
+        slug="test-event-2",
+        currency="EUR",
+        date_from=now(),
+    )
+
+    order = MagicMock()
+    order.code = "ABCDEF"
+    order.positions.all.return_value = [
+        MagicMock(price=Decimal("100"), tax_value=Decimal("0"))
+    ]
+
+    record_platform_fee_on_order_paid(sender=event, order=order)
+
+    # Should not create a usage record for 0% fee
+    assert UsageRecord.objects.count() == 0


### PR DESCRIPTION
## Description

Resolves **Issue #19**: Records tier-specific platform fees when an order is paid.

### Currency Conversion
If the event currency differs from the organizer's subscription billing currency, this uses the native Eventyay `GlobalSettingsObject` (which caches ECB rates) to securely look up the exchange rate and convert the fee amount into the billing currency.

This PR is correctly stacked on top of PR #58. Once #58 is merged, this will automatically target `dev`.

## Summary by Sourcery

Record subscription-tier platform fees for paid orders with currency conversion and reliable, idempotent usage tracking.

New Features:
- Record tier-specific platform fee usage when orders are paid, based on the active subscription entitlement.
- Convert platform fees into the subscription billing currency using cached ECB exchange rates when currencies differ.

Enhancements:
- Make paid-order fee recording resilient to varying payment timestamp sources and idempotent across repeated signal delivery.

Tests:
- Add coverage for fee calculation, zero-fee tiers, currency conversion, missing exchange rates, idempotency, and payment timestamps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic platform-fee recording when an order is paid.
  - Platform fees are calculated from order prices excluding taxes and can be converted to the subscription’s billing currency.
  - Fees are recorded only for organizers with an active, fee-enabled subscription.

- **Tests**
  - Added coverage for fee calculation, zero-fee configurations, and currency conversion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->