### PR TITLE
feat: implement monthly usage aggregation for integer capabilities

### DIFF
--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -1,3 +1,4 @@
+from django.db.models import Sum
 from django.dispatch import receiver
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -193,8 +194,6 @@ if entitlement_check and EntitlementDecision:
         if cap_def.value_type == CapabilityValueType.INTEGER:
             total_quantity = quantity
             if capability.endswith(".monthly"):
-                from django.db.models import Sum
-
                 from .models import UsageRecord
 
                 usage_agg = UsageRecord.objects.filter(

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -191,11 +191,27 @@ if entitlement_check and EntitlementDecision:
                 )
 
         if cap_def.value_type == CapabilityValueType.INTEGER:
-            if value is not None and quantity > value:
+            total_quantity = quantity
+            if capability.endswith('.monthly'):
+                from django.db.models import Sum
+                from .models import UsageRecord
+                
+                usage_agg = UsageRecord.objects.filter(
+                    organizer=organizer,
+                    capability=capability,
+                    occurred_at__year=current_time.year,
+                    occurred_at__month=current_time.month,
+                ).aggregate(total=Sum('quantity'))
+                
+                past_usage = usage_agg['total'] or 0
+                total_quantity = quantity + int(past_usage)
+
+            if value is not None and total_quantity > value:
                 return EntitlementDecision(
                     allowed=False,
                     reason_code="tier_limit_exceeded",
                     limit=value,
+                    used=past_usage if capability.endswith('.monthly') else None,
                     message="You have reached the maximum limit for this feature on your current plan.",
                 )
             return EntitlementDecision(allowed=True, limit=value)

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -192,18 +192,19 @@ if entitlement_check and EntitlementDecision:
 
         if cap_def.value_type == CapabilityValueType.INTEGER:
             total_quantity = quantity
-            if capability.endswith('.monthly'):
+            if capability.endswith(".monthly"):
                 from django.db.models import Sum
+
                 from .models import UsageRecord
-                
+
                 usage_agg = UsageRecord.objects.filter(
                     organizer=organizer,
                     capability=capability,
                     occurred_at__year=current_time.year,
                     occurred_at__month=current_time.month,
-                ).aggregate(total=Sum('quantity'))
-                
-                past_usage = usage_agg['total'] or 0
+                ).aggregate(total=Sum("quantity"))
+
+                past_usage = usage_agg["total"] or 0
                 total_quantity = quantity + int(past_usage)
 
             if value is not None and total_quantity > value:
@@ -211,7 +212,7 @@ if entitlement_check and EntitlementDecision:
                     allowed=False,
                     reason_code="tier_limit_exceeded",
                     limit=value,
-                    used=past_usage if capability.endswith('.monthly') else None,
+                    used=past_usage if capability.endswith(".monthly") else None,
                     message="You have reached the maximum limit for this feature on your current plan.",
                 )
             return EntitlementDecision(allowed=True, limit=value)


### PR DESCRIPTION
## Description

Resolves the issue where integer capabilities (like `email.bulk.monthly`) were not aggregating previous usage in the billing cycle.

This adds a check for capabilities ending in `.monthly` to dynamically sum up the `UsageRecord` quantities for the current month and append them to the requested quantity before evaluating against the limit.

### Scope of restriction
Together with the core Eventyay hook (https://github.com/fossasia/eventyay/pull/5571), this fully enforces the limits on:
- Mass emails sent to **Speakers / Sessions**
- Mass emails sent to **Event Team members / Staff**

It explicitly does **NOT** restrict transactional emails like post-purchase ticket deliveries, automated payment reminders, or other automated queued emails.

## Summary by Sourcery

Enforce monthly integer capability limits using cumulative usage from the current billing month.

New Features:
- Add monthly aggregation for integer capability usage so requests account for prior usage in the current billing month.

Bug Fixes:
- Fix monthly integer capability limits being evaluated only against the current request instead of cumulative monthly usage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Monthly usage is now included when checking whether an integer-based capability exceeds its tier limit.
  - Requests are evaluated against both the requested quantity and usage already accumulated during the current month.
  - Limit-exceeded results now report the amount already used, providing clearer usage information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->