### PR TITLE
fix: use SplitDateTimeField in SubscriptionAdminForm to fix subscription edit error

### DIFF
--- a/eventyay_business/forms.py
+++ b/eventyay_business/forms.py
@@ -14,8 +14,12 @@ from .models import (
 
 try:
     from eventyay.base.forms.widgets import SplitDateTimePickerWidget
+    from eventyay.control.forms import SplitDateTimeField
 except ImportError:
-    from django.forms import SplitDateTimeWidget as SplitDateTimePickerWidget
+    from django.forms import (
+        SplitDateTimeField,
+        SplitDateTimeWidget as SplitDateTimePickerWidget,
+    )
 
 
 class TierForm(forms.ModelForm):
@@ -144,6 +148,11 @@ class SubscriptionAdminForm(forms.ModelForm):
             "stripe_customer_id",
             "stripe_subscription_id",
         ]
+        field_classes = {
+            "starts_at": SplitDateTimeField,
+            "ends_at": SplitDateTimeField,
+            "cancel_at": SplitDateTimeField,
+        }
         widgets = {
             "starts_at": SplitDateTimePickerWidget(),
             "ends_at": SplitDateTimePickerWidget(),

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -4,6 +4,22 @@ from eventyay.base.models import Organizer
 from eventyay_business.models import Subscription
 
 
+@pytest.fixture
+def business_admin_client(admin_client, admin_user):
+    from eventyay.base.models.auth import StaffSession
+
+    session = admin_client.session
+    session.save()
+    StaffSession.objects.create(
+        user=admin_user,
+        session_key=session.session_key,
+        comment="test",
+    )
+    admin_user.is_staff = True
+    admin_user.save()
+    return admin_client
+
+
 @pytest.mark.django_db
 def test_organizer_auto_assign_free_tier():
     # Creating an organizer should trigger the post_save signal
@@ -14,3 +30,65 @@ def test_organizer_auto_assign_free_tier():
     assert sub is not None
     assert sub.status == "active"
     assert sub.tier_version.tier.slug == "free"
+
+
+@pytest.mark.django_db
+def test_subscription_admin_form_valid_with_split_datetime():
+    from eventyay_business.forms import SubscriptionAdminForm
+
+    org = Organizer.objects.create(name="Form Test Org", slug="form-test-org")
+    sub = Subscription.objects.get(organizer=org)
+
+    data = {
+        "organizer": org.pk,
+        "tier_version": sub.tier_version.pk,
+        "status": "active",
+        "billing_interval": "monthly",
+        "currency": "USD",
+        "starts_at_0": "2026-09-11",
+        "starts_at_1": "10:00:00",
+        "ends_at_0": "2026-10-11",
+        "ends_at_1": "10:00:00",
+        "cancel_at_0": "",
+        "cancel_at_1": "",
+        "stripe_customer_id": "cus_123",
+        "stripe_subscription_id": "sub_123",
+    }
+    form = SubscriptionAdminForm(data=data, instance=sub)
+    assert form.is_valid(), form.errors
+    saved_sub = form.save()
+    assert saved_sub.starts_at.year == 2026
+    assert saved_sub.ends_at.month == 10
+    assert saved_sub.cancel_at is None
+
+
+@pytest.mark.django_db
+def test_subscription_edit_view_post(business_admin_client):
+    from django.urls import reverse
+
+    org = Organizer.objects.create(name="Edit View Org", slug="edit-view-org")
+    sub = Subscription.objects.get(organizer=org)
+
+    url = reverse("plugins:eventyay_business:subscriptions.edit", kwargs={"pk": sub.pk})
+    get_response = business_admin_client.get(url)
+    assert get_response.status_code == 200
+
+    post_data = {
+        "organizer": org.pk,
+        "tier_version": sub.tier_version.pk,
+        "status": "active",
+        "billing_interval": "monthly",
+        "currency": "EUR",
+        "starts_at_0": "2026-09-01",
+        "starts_at_1": "08:00:00",
+        "ends_at_0": "",
+        "ends_at_1": "",
+        "cancel_at_0": "",
+        "cancel_at_1": "",
+        "stripe_customer_id": "",
+        "stripe_subscription_id": "",
+    }
+    post_response = business_admin_client.post(url, post_data, follow=True)
+    assert post_response.status_code == 200
+    sub.refresh_from_db()
+    assert sub.currency == "EUR"


### PR DESCRIPTION
Closes #60

### Description
Fixes `AttributeError: 'list' object has no attribute 'strip'` when creating or editing subscriptions in the global business admin.

### Root Cause
`SubscriptionAdminForm.Meta` specifies `SplitDateTimePickerWidget` for `starts_at`, `ends_at`, and `cancel_at`. Because `SplitDateTimePickerWidget` is a multi-widget returning `[date, time]`, the default `forms.DateTimeField` used by `ModelForm` expects a string and attempts `value.strip()`, raising an `AttributeError`.

### Solution
- Added `field_classes` in `SubscriptionAdminForm.Meta` with `SplitDateTimeField` (importing from `eventyay.control.forms` with fallback to `django.forms.SplitDateTimeField`).
- Added unit tests in `tests/test_subscriptions.py` for both `SubscriptionAdminForm` validation and `SubscriptionUpdateView` POST submission.

## Summary by Sourcery

Use split date-time fields for subscription timestamps to prevent admin form submission errors.

Bug Fixes:
- Fix subscription creation and editing by correctly validating split date-time inputs in the business admin form.

Tests:
- Add form validation and admin edit-flow coverage for subscription split date-time fields.