### PR TITLE
feat(ui): display active add-ons on organiser plan and usage page

### DIFF
--- a/eventyay_business/templates/eventyay_business/organizer/plan.html
+++ b/eventyay_business/templates/eventyay_business/organizer/plan.html
@@ -26,6 +26,93 @@
                 </div>
             {% endif %}
         </div>
+    </div>
+
+    {# ── Active Add-ons Section ── #}
+    {% if active_organizer_addons or active_event_addons %}
+        <div class="panel panel-default">
+            <div class="panel-heading">
+                <h3 class="panel-title">
+                    <i class="fa fa-fw fa-puzzle-piece"></i>
+                    {% trans "Active Add-ons" %}
+                </h3>
+            </div>
+            <div class="table-responsive">
+                <table class="table table-striped" style="margin: 0;">
+                    <thead>
+                        <tr>
+                            <th>{% trans "Add-on" %}</th>
+                            <th>{% trans "Scope" %}</th>
+                            <th>{% trans "Included Quantity" %}</th>
+                            <th>{% trans "Capability & Value" %}</th>
+                            <th>{% trans "Expires / Renews" %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for oa in active_organizer_addons %}
+                            <tr>
+                                <td>
+                                    <strong>{{ oa.addon.name }}</strong>
+                                    {% if oa.addon.description %}
+                                        <div class="help-block text-muted" style="margin: 2px 0 0; font-size: 12px;">
+                                            {{ oa.addon.description }}
+                                        </div>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <span class="label label-primary">{% trans "Organisation" %}</span>
+                                </td>
+                                <td>
+                                    <strong>{{ oa.quantity }}</strong>
+                                </td>
+                                <td>
+                                    <code>{{ oa.addon.capability }}</code>
+                                    <br>
+                                    <small class="text-muted">{% trans "Allowance:" %} {{ oa.addon.entitlement_value }}</small>
+                                </td>
+                                <td>
+                                    {% if oa.ends_at %}
+                                        {{ oa.ends_at|date:"SHORT_DATETIME_FORMAT" }}
+                                    {% else %}
+                                        <span class="text-muted">{% trans "Never / Continuous" %}</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                        {% for ea in active_event_addons %}
+                            <tr>
+                                <td>
+                                    <strong>{{ ea.addon.name }}</strong>
+                                    <div class="help-block text-muted" style="margin: 2px 0 0; font-size: 12px;">
+                                        {% trans "Event:" %} <strong>{{ ea.event.name }}</strong>
+                                    </div>
+                                </td>
+                                <td>
+                                    <span class="label label-info">{% trans "Event" %}</span>
+                                </td>
+                                <td>
+                                    <strong>{{ ea.quantity }}</strong>
+                                </td>
+                                <td>
+                                    <code>{{ ea.addon.capability }}</code>
+                                    <br>
+                                    <small class="text-muted">{% trans "Allowance:" %} {{ ea.addon.entitlement_value }}</small>
+                                </td>
+                                <td>
+                                    {% if ea.ends_at %}
+                                        {{ ea.ends_at|date:"SHORT_DATETIME_FORMAT" }}
+                                    {% else %}
+                                        <span class="text-muted">{% trans "Never / Continuous" %}</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    {% endif %}
+
     <style>
         /* Explicitly disable any browser or framework animations on the expandable sections */
         details, details *, details summary, details > div {

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -30,6 +30,9 @@ from .forms import (
 )
 from .models import (
     AddonDefinition,
+    AddonStatus,
+    EventAddon,
+    OrganizerAddon,
     Subscription,
     SubscriptionStatus,
     Tier,
@@ -368,6 +371,31 @@ class OrganizerPlanView(
         ctx["developer_entitlements"] = sorted(
             developer_entitlements, key=lambda x: x["capability"].category
         )
+
+        ctx["active_organizer_addons"] = (
+            OrganizerAddon.objects.filter(
+                organizer=organizer,
+                addon__active=True,
+                status=AddonStatus.ACTIVE,
+                starts_at__lte=current_time,
+            )
+            .exclude(ends_at__lt=current_time)
+            .select_related("addon")
+            .order_by("addon__name")
+        )
+
+        ctx["active_event_addons"] = (
+            EventAddon.objects.filter(
+                event__organizer=organizer,
+                addon__active=True,
+                status=AddonStatus.ACTIVE,
+                starts_at__lte=current_time,
+            )
+            .exclude(ends_at__lt=current_time)
+            .select_related("addon", "event")
+            .order_by("event__name", "addon__name")
+        )
+
         return ctx
 
 

--- a/tests/test_subscriptions.py
+++ b/tests/test_subscriptions.py
@@ -1,4 +1,5 @@
 import pytest
+from django.test import override_settings
 from eventyay.base.models import Organizer
 
 from eventyay_business.models import Subscription
@@ -92,3 +93,85 @@ def test_subscription_edit_view_post(business_admin_client):
     assert post_response.status_code == 200
     sub.refresh_from_db()
     assert sub.currency == "EUR"
+
+
+@pytest.mark.django_db
+@override_settings(SITE_URL="https://testserver")
+def test_organizer_plan_view_shows_active_addons(business_admin_client):
+    from django.urls import reverse
+    from django.utils.timezone import now
+    from eventyay.base.models import Event
+
+    from eventyay_business.models import (
+        AddonAssignmentScope,
+        AddonDefinition,
+        AddonStatus,
+        EventAddon,
+        OrganizerAddon,
+    )
+
+    org = Organizer.objects.create(name="Plan View Org", slug="plan-view-org")
+    event = Event.objects.create(
+        organizer=org, name="Plan View Event", slug="plan-view-event", date_from=now()
+    )
+
+    # 1. Active Organizer Add-on
+    org_addon_def = AddonDefinition.objects.create(
+        name="Extra Admin Pack",
+        slug="extra-admin-pack",
+        capability="organizer.full_admins",
+        entitlement_value="3",
+        assignment_scope=AddonAssignmentScope.ORGANIZER,
+    )
+    OrganizerAddon.objects.create(
+        organizer=org,
+        addon=org_addon_def,
+        quantity=1,
+        status=AddonStatus.ACTIVE,
+    )
+
+    # 2. Active Event Add-on
+    event_addon_def = AddonDefinition.objects.create(
+        name="Live Interpretation Pack",
+        slug="live-interpretation-pack",
+        capability="video.interpretation",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.EVENT,
+    )
+    EventAddon.objects.create(
+        event=event,
+        addon=event_addon_def,
+        quantity=2,
+        status=AddonStatus.ACTIVE,
+    )
+
+    # 3. Inactive/Expired Add-on (should not show)
+    inactive_addon_def = AddonDefinition.objects.create(
+        name="Expired Addon Pack",
+        slug="expired-addon-pack",
+        capability="video.loungemesh",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.ORGANIZER,
+    )
+    OrganizerAddon.objects.create(
+        organizer=org,
+        addon=inactive_addon_def,
+        quantity=1,
+        status=AddonStatus.EXPIRED,
+    )
+
+    url = reverse(
+        "plugins:eventyay_business:organizer.plan", kwargs={"organizer": org.slug}
+    )
+    response = business_admin_client.get(url)
+    assert response.status_code == 200
+    content = response.content.decode()
+
+    # Active Add-ons section and items should be present
+    assert "Active Add-ons" in content
+    assert "Extra Admin Pack" in content
+    assert "Live Interpretation Pack" in content
+    assert "Plan View Event" in content
+
+    # Inactive add-on should not be displayed
+    assert "Expired Addon Pack" not in content


### PR DESCRIPTION
Closes #64

## Summary
Displays active add-on assignments (both organization-scoped and event-scoped) on the organiser's self-service **Plan & Usage** page (`/control/organizer/<slug>/business/plan/`).

### Changes
- **Views** (`eventyay_business/views.py`): In `OrganizerPlanView.get_context_data`, queries active, non-expired `OrganizerAddon` and `EventAddon` records for the current organizer where `addon.active=True`.
- **Templates** (`eventyay_business/templates/eventyay_business/organizer/plan.html`): Added an **Active Add-ons** panel section displaying add-on name, description, assignment scope (Organisation vs Event), included quantity, capability allowance, and expiration/renewal timestamp.
- **Tests** (`tests/test_subscriptions.py`): Added test coverage verifying that active organisation and event add-ons render with details and that inactive/expired add-ons are omitted.