### PR TITLE
feat(admin): add admin UI for assigning add-ons to organizers and events

### DIFF
--- a/eventyay_business/forms.py
+++ b/eventyay_business/forms.py
@@ -290,6 +290,17 @@ class OrganizerAddonForm(forms.ModelForm):
             "ends_at": SplitDateTimePickerWidget(),
         }
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        from .models import AddonAssignmentScope, AddonDefinition
+
+        qs = AddonDefinition.objects.filter(
+            assignment_scope=AddonAssignmentScope.ORGANIZER
+        )
+        if self.instance and self.instance.pk and self.instance.addon_id:
+            qs = qs | AddonDefinition.objects.filter(pk=self.instance.addon_id)
+        self.fields["addon"].queryset = qs.distinct()
+
 
 class EventAddonForm(forms.ModelForm):
     class Meta:
@@ -303,3 +314,12 @@ class EventAddonForm(forms.ModelForm):
             "starts_at": SplitDateTimePickerWidget(),
             "ends_at": SplitDateTimePickerWidget(),
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        from .models import AddonAssignmentScope, AddonDefinition
+
+        qs = AddonDefinition.objects.filter(assignment_scope=AddonAssignmentScope.EVENT)
+        if self.instance and self.instance.pk and self.instance.addon_id:
+            qs = qs | AddonDefinition.objects.filter(pk=self.instance.addon_id)
+        self.fields["addon"].queryset = qs.distinct()

--- a/eventyay_business/templates/eventyay_business/addons/assignments/event_list.html
+++ b/eventyay_business/templates/eventyay_business/addons/assignments/event_list.html
@@ -1,0 +1,84 @@
+{% extends "pretixcontrol/admin/base.html" %}
+{% load i18n %}
+
+{% block title %}
+    {% trans "Event Add-on Assignments" %}
+{% endblock %}
+
+{% block content %}
+    <h1>{% trans "Add-ons" %}</h1>
+
+    {% include "eventyay_business/addons/nav_tabs.html" with active_tab="events" %}
+
+    <p>
+        <a href="{% url 'plugins:eventyay_business:addons.assignments.event.create' %}" class="btn btn-primary">
+            <i class="fa fa-plus"></i> {% trans "Assign Add-on to Event" %}
+        </a>
+    </p>
+
+    {% if assignments|length == 0 %}
+        <div class="empty-collection">
+            <p>
+                {% blocktrans trimmed %}
+                    No event add-on assignments found.
+                {% endblocktrans %}
+            </p>
+        </div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-hover table-striped">
+                <thead>
+                    <tr>
+                        <th>{% trans "Event" %}</th>
+                        <th>{% trans "Organizer" %}</th>
+                        <th>{% trans "Add-on" %}</th>
+                        <th>{% trans "Quantity" %}</th>
+                        <th>{% trans "Status" %}</th>
+                        <th>{% trans "Starts at" %}</th>
+                        <th>{% trans "Ends at" %}</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in assignments %}
+                        <tr>
+                            <td>
+                                <strong>{{ item.event.name }}</strong>
+                                <br>
+                                <small class="text-muted">{{ item.event.slug }}</small>
+                            </td>
+                            <td>
+                                {{ item.event.organizer.name }}
+                            </td>
+                            <td>
+                                <strong>{{ item.addon.name }}</strong>
+                                <br>
+                                <code>{{ item.addon.capability }}</code>
+                                <small class="text-muted">({{ item.addon.entitlement_value }})</small>
+                            </td>
+                            <td>{{ item.quantity }}</td>
+                            <td>
+                                {% if item.status == "active" and item.is_active %}
+                                    <span class="label label-success">{% trans "Active" %}</span>
+                                {% elif item.status == "active" %}
+                                    <span class="label label-warning">{% trans "Scheduled / Inactive" %}</span>
+                                {% elif item.status == "expired" %}
+                                    <span class="label label-default">{% trans "Expired" %}</span>
+                                {% else %}
+                                    <span class="label label-danger">{% trans "Canceled" %}</span>
+                                {% endif %}
+                            </td>
+                            <td>{{ item.starts_at|date:"SHORT_DATETIME_FORMAT" }}</td>
+                            <td>{{ item.ends_at|date:"SHORT_DATETIME_FORMAT"|default:"-" }}</td>
+                            <td class="text-right">
+                                <a href="{% url 'plugins:eventyay_business:addons.assignments.event.edit' pk=item.pk %}" class="btn btn-default btn-sm">
+                                    <i class="fa fa-edit"></i>
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/eventyay_business/templates/eventyay_business/addons/assignments/form.html
+++ b/eventyay_business/templates/eventyay_business/addons/assignments/form.html
@@ -1,0 +1,57 @@
+{% extends "pretixcontrol/admin/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block title %}
+    {% if object %}
+        {% if assignment_type == "event" %}
+            {% trans "Edit event add-on assignment" %}
+        {% else %}
+            {% trans "Edit organizer add-on assignment" %}
+        {% endif %}
+    {% else %}
+        {% if assignment_type == "event" %}
+            {% trans "Assign add-on to event" %}
+        {% else %}
+            {% trans "Assign add-on to organizer" %}
+        {% endif %}
+    {% endif %}
+{% endblock %}
+
+{% block content %}
+    <h1>
+        {% if object %}
+            {% if assignment_type == "event" %}
+                {% trans "Edit Event Add-on Assignment" %}
+            {% else %}
+                {% trans "Edit Organizer Add-on Assignment" %}
+            {% endif %}
+        {% else %}
+            {% if assignment_type == "event" %}
+                {% trans "Assign Add-on to Event" %}
+            {% else %}
+                {% trans "Assign Add-on to Organizer" %}
+            {% endif %}
+        {% endif %}
+    </h1>
+
+    <form method="post" class="form-horizontal">
+        {% csrf_token %}
+        {% bootstrap_form form layout='horizontal' %}
+        
+        <div class="form-group submit-group">
+            <button type="submit" class="btn btn-primary btn-save">
+                {% trans "Save" %}
+            </button>
+            {% if assignment_type == "event" %}
+                <a href="{% url "plugins:eventyay_business:addons.assignments.event.list" %}" class="btn btn-default btn-cancel">
+                    {% trans "Cancel" %}
+                </a>
+            {% else %}
+                <a href="{% url "plugins:eventyay_business:addons.assignments.organizer.list" %}" class="btn btn-default btn-cancel">
+                    {% trans "Cancel" %}
+                </a>
+            {% endif %}
+        </div>
+    </form>
+{% endblock %}

--- a/eventyay_business/templates/eventyay_business/addons/assignments/organizer_list.html
+++ b/eventyay_business/templates/eventyay_business/addons/assignments/organizer_list.html
@@ -1,0 +1,80 @@
+{% extends "pretixcontrol/admin/base.html" %}
+{% load i18n %}
+
+{% block title %}
+    {% trans "Organizer Add-on Assignments" %}
+{% endblock %}
+
+{% block content %}
+    <h1>{% trans "Add-ons" %}</h1>
+
+    {% include "eventyay_business/addons/nav_tabs.html" with active_tab="organizers" %}
+
+    <p>
+        <a href="{% url 'plugins:eventyay_business:addons.assignments.organizer.create' %}" class="btn btn-primary">
+            <i class="fa fa-plus"></i> {% trans "Assign Add-on to Organizer" %}
+        </a>
+    </p>
+
+    {% if assignments|length == 0 %}
+        <div class="empty-collection">
+            <p>
+                {% blocktrans trimmed %}
+                    No organizer add-on assignments found.
+                {% endblocktrans %}
+            </p>
+        </div>
+    {% else %}
+        <div class="table-responsive">
+            <table class="table table-hover table-striped">
+                <thead>
+                    <tr>
+                        <th>{% trans "Organizer" %}</th>
+                        <th>{% trans "Add-on" %}</th>
+                        <th>{% trans "Quantity" %}</th>
+                        <th>{% trans "Status" %}</th>
+                        <th>{% trans "Starts at" %}</th>
+                        <th>{% trans "Ends at" %}</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for item in assignments %}
+                        <tr>
+                            <td>
+                                <strong>{{ item.organizer.name }}</strong>
+                                <br>
+                                <small class="text-muted">{{ item.organizer.slug }}</small>
+                            </td>
+                            <td>
+                                <strong>{{ item.addon.name }}</strong>
+                                <br>
+                                <code>{{ item.addon.capability }}</code>
+                                <small class="text-muted">({{ item.addon.entitlement_value }})</small>
+                            </td>
+                            <td>{{ item.quantity }}</td>
+                            <td>
+                                {% if item.status == "active" and item.is_active %}
+                                    <span class="label label-success">{% trans "Active" %}</span>
+                                {% elif item.status == "active" %}
+                                    <span class="label label-warning">{% trans "Scheduled / Inactive" %}</span>
+                                {% elif item.status == "expired" %}
+                                    <span class="label label-default">{% trans "Expired" %}</span>
+                                {% else %}
+                                    <span class="label label-danger">{% trans "Canceled" %}</span>
+                                {% endif %}
+                            </td>
+                            <td>{{ item.starts_at|date:"SHORT_DATETIME_FORMAT" }}</td>
+                            <td>{{ item.ends_at|date:"SHORT_DATETIME_FORMAT"|default:"-" }}</td>
+                            <td class="text-right">
+                                <a href="{% url 'plugins:eventyay_business:addons.assignments.organizer.edit' pk=item.pk %}" class="btn btn-default btn-sm">
+                                    <i class="fa fa-edit"></i>
+                                </a>
+                            </td>
+                        </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>
+    {% endif %}
+{% endblock %}

--- a/eventyay_business/templates/eventyay_business/addons/list.html
+++ b/eventyay_business/templates/eventyay_business/addons/list.html
@@ -6,7 +6,10 @@
 {% endblock %}
 
 {% block content %}
-    <h1>{% trans "Add-on Definitions" %}</h1>
+    <h1>{% trans "Add-ons" %}</h1>
+
+    {% include "eventyay_business/addons/nav_tabs.html" with active_tab="definitions" %}
+
     <p>
         <a href="{% url 'plugins:eventyay_business:addons.create' %}" class="btn btn-default">
             <i class="fa fa-plus"></i> {% trans "Create Add-on" %}

--- a/eventyay_business/templates/eventyay_business/addons/nav_tabs.html
+++ b/eventyay_business/templates/eventyay_business/addons/nav_tabs.html
@@ -1,0 +1,18 @@
+{% load i18n %}
+<ul class="nav nav-tabs" style="margin-bottom: 20px;">
+    <li class="{% if active_tab == 'definitions' %}active{% endif %}">
+        <a href="{% url 'plugins:eventyay_business:addons.list' %}">
+            <i class="fa fa-cubes"></i> {% trans "Definitions" %}
+        </a>
+    </li>
+    <li class="{% if active_tab == 'organizers' %}active{% endif %}">
+        <a href="{% url 'plugins:eventyay_business:addons.assignments.organizer.list' %}">
+            <i class="fa fa-building-o"></i> {% trans "Organizer Assignments" %}
+        </a>
+    </li>
+    <li class="{% if active_tab == 'events' %}active{% endif %}">
+        <a href="{% url 'plugins:eventyay_business:addons.assignments.event.list' %}">
+            <i class="fa fa-calendar"></i> {% trans "Event Assignments" %}
+        </a>
+    </li>
+</ul>

--- a/eventyay_business/urls.py
+++ b/eventyay_business/urls.py
@@ -77,6 +77,37 @@ urlpatterns = [
         views.AddonDefinitionToggleActiveView.as_view(),
         name="addons.toggle",
     ),
+    # Add-on Assignments
+    path(
+        "admin/global/business/addons/assignments/organizers/",
+        views.OrganizerAddonListView.as_view(),
+        name="addons.assignments.organizer.list",
+    ),
+    path(
+        "admin/global/business/addons/assignments/organizers/create/",
+        views.OrganizerAddonCreateView.as_view(),
+        name="addons.assignments.organizer.create",
+    ),
+    path(
+        "admin/global/business/addons/assignments/organizers/<int:pk>/edit/",
+        views.OrganizerAddonUpdateView.as_view(),
+        name="addons.assignments.organizer.edit",
+    ),
+    path(
+        "admin/global/business/addons/assignments/events/",
+        views.EventAddonListView.as_view(),
+        name="addons.assignments.event.list",
+    ),
+    path(
+        "admin/global/business/addons/assignments/events/create/",
+        views.EventAddonCreateView.as_view(),
+        name="addons.assignments.event.create",
+    ),
+    path(
+        "admin/global/business/addons/assignments/events/<int:pk>/edit/",
+        views.EventAddonUpdateView.as_view(),
+        name="addons.assignments.event.edit",
+    ),
     # Organizer URLs
     path(
         "control/organizer/<str:organizer>/business/plan/",

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -23,6 +23,8 @@ from eventyay.control.views.organizer_views.organizer_detail_view_mixin import (
 from .capabilities import get_all_capabilities
 from .forms import (
     AddonDefinitionForm,
+    EventAddonForm,
+    OrganizerAddonForm,
     SubscriptionAdminForm,
     TierEntitlementFormSet,
     TierForm,
@@ -439,3 +441,89 @@ class AddonDefinitionToggleActiveView(AdministratorPermissionRequiredMixin, View
             % {"name": addon.name, "status": status_text},
         )
         return redirect("plugins:eventyay_business:addons.list")
+
+
+class OrganizerAddonListView(AdministratorPermissionRequiredMixin, ListView):
+    model = OrganizerAddon
+    template_name = "eventyay_business/addons/assignments/organizer_list.html"
+    context_object_name = "assignments"
+
+    def get_queryset(self):
+        return OrganizerAddon.objects.select_related("organizer", "addon").order_by(
+            "-starts_at", "-id"
+        )
+
+
+class OrganizerAddonCreateView(AdministratorPermissionRequiredMixin, CreateView):
+    model = OrganizerAddon
+    form_class = OrganizerAddonForm
+    template_name = "eventyay_business/addons/assignments/form.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["assignment_type"] = "organizer"
+        return ctx
+
+    def form_valid(self, form):
+        self.object = form.save()
+        messages.success(self.request, _("Organizer add-on assigned successfully."))
+        return redirect("plugins:eventyay_business:addons.assignments.organizer.list")
+
+
+class OrganizerAddonUpdateView(AdministratorPermissionRequiredMixin, UpdateView):
+    model = OrganizerAddon
+    form_class = OrganizerAddonForm
+    template_name = "eventyay_business/addons/assignments/form.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["assignment_type"] = "organizer"
+        return ctx
+
+    def form_valid(self, form):
+        self.object = form.save()
+        messages.success(self.request, _("Organizer add-on assignment updated."))
+        return redirect("plugins:eventyay_business:addons.assignments.organizer.list")
+
+
+class EventAddonListView(AdministratorPermissionRequiredMixin, ListView):
+    model = EventAddon
+    template_name = "eventyay_business/addons/assignments/event_list.html"
+    context_object_name = "assignments"
+
+    def get_queryset(self):
+        return EventAddon.objects.select_related(
+            "event", "event__organizer", "addon"
+        ).order_by("-starts_at", "-id")
+
+
+class EventAddonCreateView(AdministratorPermissionRequiredMixin, CreateView):
+    model = EventAddon
+    form_class = EventAddonForm
+    template_name = "eventyay_business/addons/assignments/form.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["assignment_type"] = "event"
+        return ctx
+
+    def form_valid(self, form):
+        self.object = form.save()
+        messages.success(self.request, _("Event add-on assigned successfully."))
+        return redirect("plugins:eventyay_business:addons.assignments.event.list")
+
+
+class EventAddonUpdateView(AdministratorPermissionRequiredMixin, UpdateView):
+    model = EventAddon
+    form_class = EventAddonForm
+    template_name = "eventyay_business/addons/assignments/form.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["assignment_type"] = "event"
+        return ctx
+
+    def form_valid(self, form):
+        self.object = form.save()
+        messages.success(self.request, _("Event add-on assignment updated."))
+        return redirect("plugins:eventyay_business:addons.assignments.event.list")

--- a/tests/test_addon_admin.py
+++ b/tests/test_addon_admin.py
@@ -7,6 +7,9 @@ from eventyay_business.models import (
     AddonAssignmentScope,
     AddonDefinition,
     AddonPricingMode,
+    AddonStatus,
+    EventAddon,
+    OrganizerAddon,
 )
 
 
@@ -179,3 +182,131 @@ def test_addon_legacy_unchanged_capability_allowed(business_admin_client):
     addon.refresh_from_db()
     assert addon.name == "Legacy Addon Renamed"
     assert addon.price == Decimal("20.00")
+
+
+@pytest.mark.django_db
+def test_organizer_addon_assignment_views(business_admin_client):
+    from eventyay.base.models import Organizer
+
+    org = Organizer.objects.create(name="Assign Org", slug="assign-org")
+    addon = AddonDefinition.objects.create(
+        name="Org Pack",
+        slug="org-pack",
+        capability="organizer.full_admins",
+        entitlement_value="2",
+        assignment_scope=AddonAssignmentScope.ORGANIZER,
+    )
+
+    # List view
+    list_url = reverse("plugins:eventyay_business:addons.assignments.organizer.list")
+    resp = business_admin_client.get(list_url)
+    assert resp.status_code == 200
+
+    # Create assignment
+    create_url = reverse(
+        "plugins:eventyay_business:addons.assignments.organizer.create"
+    )
+    resp = business_admin_client.post(
+        create_url,
+        {
+            "organizer": org.pk,
+            "addon": addon.pk,
+            "quantity": 3,
+            "status": "active",
+            "starts_at_0": "2026-09-01",
+            "starts_at_1": "10:00:00",
+            "ends_at_0": "",
+            "ends_at_1": "",
+        },
+    )
+    assert resp.status_code == 302
+    assignment = OrganizerAddon.objects.get(organizer=org, addon=addon)
+    assert assignment.quantity == 3
+    assert assignment.status == AddonStatus.ACTIVE
+
+    # Edit assignment
+    edit_url = reverse(
+        "plugins:eventyay_business:addons.assignments.organizer.edit",
+        kwargs={"pk": assignment.pk},
+    )
+    resp = business_admin_client.post(
+        edit_url,
+        {
+            "organizer": org.pk,
+            "addon": addon.pk,
+            "quantity": 5,
+            "status": "canceled",
+            "starts_at_0": "2026-09-01",
+            "starts_at_1": "10:00:00",
+            "ends_at_0": "2026-09-30",
+            "ends_at_1": "23:59:59",
+        },
+    )
+    assert resp.status_code == 302
+    assignment.refresh_from_db()
+    assert assignment.quantity == 5
+    assert assignment.status == AddonStatus.CANCELED
+
+
+@pytest.mark.django_db
+def test_event_addon_assignment_views(business_admin_client):
+    from django.utils.timezone import now
+    from eventyay.base.models import Event, Organizer
+
+    org = Organizer.objects.create(name="Event Org", slug="event-org")
+    event = Event.objects.create(
+        organizer=org, name="Assign Event", slug="assign-event", date_from=now()
+    )
+    addon = AddonDefinition.objects.create(
+        name="Event Pack",
+        slug="event-pack",
+        capability="video.jitsi.concurrent_rooms",
+        entitlement_value="5",
+        assignment_scope=AddonAssignmentScope.EVENT,
+    )
+
+    # List view
+    list_url = reverse("plugins:eventyay_business:addons.assignments.event.list")
+    resp = business_admin_client.get(list_url)
+    assert resp.status_code == 200
+
+    # Create assignment
+    create_url = reverse("plugins:eventyay_business:addons.assignments.event.create")
+    resp = business_admin_client.post(
+        create_url,
+        {
+            "event": event.pk,
+            "addon": addon.pk,
+            "quantity": 2,
+            "status": "active",
+            "starts_at_0": "2026-09-01",
+            "starts_at_1": "12:00:00",
+            "ends_at_0": "",
+            "ends_at_1": "",
+        },
+    )
+    assert resp.status_code == 302
+    assignment = EventAddon.objects.get(event=event, addon=addon)
+    assert assignment.quantity == 2
+
+    # Edit assignment
+    edit_url = reverse(
+        "plugins:eventyay_business:addons.assignments.event.edit",
+        kwargs={"pk": assignment.pk},
+    )
+    resp = business_admin_client.post(
+        edit_url,
+        {
+            "event": event.pk,
+            "addon": addon.pk,
+            "quantity": 4,
+            "status": "active",
+            "starts_at_0": "2026-09-01",
+            "starts_at_1": "12:00:00",
+            "ends_at_0": "",
+            "ends_at_1": "",
+        },
+    )
+    assert resp.status_code == 302
+    assignment.refresh_from_db()
+    assert assignment.quantity == 4


### PR DESCRIPTION
Closes #66

## Summary
Provides platform administrators with an interface to assign add-on packages to specific organizers and events, as well as manage, edit, and revoke existing assignments.

### Changes
- **Navigation & Tabs**: Added a unified sub-navigation bar across Add-on admin pages with three tabs:
  1. **Definitions** (`/admin/global/business/addons/`)
  2. **Organizer Assignments** (`/admin/global/business/addons/assignments/organizers/`)
  3. **Event Assignments** (`/admin/global/business/addons/assignments/events/`)
- **Views & URLs**:
  - `OrganizerAddonListView`, `OrganizerAddonCreateView`, `OrganizerAddonUpdateView`
  - `EventAddonListView`, `EventAddonCreateView`, `EventAddonUpdateView`
- **Forms**: Updated `OrganizerAddonForm` and `EventAddonForm` to dynamically filter available add-on choices by assignment scope (`organizer` vs `event`).
- **Templates**:
  - Created `nav_tabs.html`, `organizer_list.html`, `event_list.html`, and `form.html`.
  - Display statuses with visual badges: Active, Scheduled / Inactive, Expired, Canceled.
- **Tests**: Added full CRUD test coverage in `tests/test_addon_admin.py`.

## Summary by Sourcery

Enable administrators to manage add-on assignments for organizers and events through the business administration UI.

New Features:
- Add administrator interfaces for listing, creating, and editing organizer- and event-level add-on assignments.
- Add unified navigation between add-on definitions and assignment management pages.
- Display assignment details and lifecycle statuses for organizers and events.

Enhancements:
- Restrict selectable add-on definitions to the appropriate organizer or event assignment scope while preserving existing assignments during edits.

Tests:
- Add CRUD coverage for organizer and event add-on assignment administration.