### PR TITLE
feat(addons): implement event-level add-ons view and management in event dashboard

### DIFF
--- a/eventyay_business/forms.py
+++ b/eventyay_business/forms.py
@@ -419,7 +419,11 @@ class OrganizerAddonPurchaseForm(forms.Form):
                 raise forms.ValidationError(_("Invalid event selected."))
 
             # Prevent duplicate active boolean add-on for the same event
-            if cap and cap.value_type == CapabilityValueType.BOOLEAN:
+            is_boolean = (cap and cap.value_type == CapabilityValueType.BOOLEAN) or (
+                self.addon.entitlement_value
+                and str(self.addon.entitlement_value).lower() in ("true", "1")
+            )
+            if is_boolean:
                 if EventAddon.objects.filter(
                     event=event,
                     capability=self.addon.capability,
@@ -430,7 +434,11 @@ class OrganizerAddonPurchaseForm(forms.Form):
                         % {"event": event.name}
                     )
         else:
-            if cap and cap.value_type == CapabilityValueType.BOOLEAN:
+            is_boolean = (cap and cap.value_type == CapabilityValueType.BOOLEAN) or (
+                self.addon.entitlement_value
+                and str(self.addon.entitlement_value).lower() in ("true", "1")
+            )
+            if is_boolean:
                 if OrganizerAddon.objects.filter(
                     organizer=self.organizer,
                     capability=self.addon.capability,
@@ -474,3 +482,75 @@ class OrganizerAddonPurchaseForm(forms.Form):
                 starts_at=now(),
             )
         return assignment
+
+
+class EventAddonPurchaseForm(forms.Form):
+    quantity = forms.IntegerField(
+        min_value=1,
+        initial=1,
+        label=_("Quantity"),
+        widget=forms.NumberInput(attrs={"class": "form-control", "min": 1}),
+    )
+
+    def __init__(self, *args, event=None, addon=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.event = event
+        self.addon = addon
+
+        if self.addon:
+            if self.addon.quantity:
+                self.fields["quantity"].initial = self.addon.quantity
+
+            from .capabilities import CapabilityValueType, get_capability
+
+            cap = get_capability(self.addon.capability)
+            if cap and cap.value_type == CapabilityValueType.BOOLEAN:
+                self.fields["quantity"].initial = 1
+                self.fields["quantity"].widget = forms.HiddenInput()
+
+    def clean(self):
+        cleaned_data = super().clean()
+        from .capabilities import CapabilityValueType, get_capability
+        from .models import AddonAssignmentScope, AddonStatus, EventAddon
+
+        if (
+            not self.addon
+            or not self.addon.active
+            or not self.addon.public
+            or self.addon.assignment_scope != AddonAssignmentScope.EVENT
+        ):
+            raise forms.ValidationError(
+                _("This add-on is currently unavailable for this event.")
+            )
+
+        cap = get_capability(self.addon.capability)
+        is_boolean = (cap and cap.value_type == CapabilityValueType.BOOLEAN) or (
+            self.addon.entitlement_value
+            and str(self.addon.entitlement_value).lower() in ("true", "1")
+        )
+        if is_boolean:
+            if EventAddon.objects.filter(
+                event=self.event,
+                capability=self.addon.capability,
+                status=AddonStatus.ACTIVE,
+            ).exists():
+                raise forms.ValidationError(
+                    _("This add-on capability is already active for %(event)s.")
+                    % {"event": self.event.name}
+                )
+
+        return cleaned_data
+
+    def save(self):
+        from django.utils.timezone import now
+
+        from .models import AddonStatus, EventAddon
+
+        qty = self.cleaned_data.get("quantity") or 1
+        return EventAddon.objects.create(
+            event=self.event,
+            addon=self.addon,
+            quantity=qty,
+            status=AddonStatus.ACTIVE,
+            starts_at=now(),
+        )

--- a/eventyay_business/signals.py
+++ b/eventyay_business/signals.py
@@ -8,10 +8,15 @@ from django.utils.translation import gettext_lazy as _
 logger = logging.getLogger(__name__)
 
 try:
-    from eventyay.control.signals import nav_global, nav_organizer
+    from eventyay.control.signals import (
+        nav_event_settings,
+        nav_global,
+        nav_organizer,
+    )
 except ImportError:
     nav_global = None
     nav_organizer = None
+    nav_event_settings = None
 
 try:
     from eventyay.base.entitlements import EntitlementDecision
@@ -310,6 +315,49 @@ if nav_organizer:
                 ),
                 "icon": "credit-card",
                 "position": 100,
+            }
+        ]
+
+
+if nav_event_settings:
+
+    @receiver(nav_event_settings, dispatch_uid="business_event_addons_nav")
+    def business_event_addons_nav(sender, request, **kwargs):
+        url = getattr(request, "resolver_match", None)
+        if not url:
+            return []
+
+        user = getattr(request, "user", None)
+        if not user or not user.is_authenticated:
+            return []
+
+        organizer = getattr(request, "organizer", None) or getattr(
+            sender, "organizer", None
+        )
+        event = getattr(request, "event", None) or sender
+        if not organizer or not event:
+            return []
+
+        if not user.has_event_permission(
+            organizer, event, "can_change_event_settings", request=request
+        ):
+            return []
+
+        return [
+            {
+                "label": _("Add-ons & Modules"),
+                "url": reverse(
+                    "plugins:eventyay_business:event.addons",
+                    kwargs={
+                        "organizer": organizer.slug,
+                        "event": event.slug,
+                    },
+                ),
+                "active": (
+                    url.namespace == "plugins:eventyay_business"
+                    and url.url_name.startswith("event.addon")
+                ),
+                "icon": "puzzle-piece",
             }
         ]
 

--- a/eventyay_business/templates/eventyay_business/event/addon_purchase.html
+++ b/eventyay_business/templates/eventyay_business/event/addon_purchase.html
@@ -1,0 +1,79 @@
+{% extends "pretixcontrol/event/base.html" %}
+{% load i18n %}
+{% load static %}
+{% load bootstrap3 %}
+
+{% block title %}{% trans "Enable Add-on" %} - {{ addon.name }}{% endblock %}
+
+{% block content %}
+    <h1>
+        {% trans "Enable Add-on" %}: {{ addon.name }}
+        <small>{{ request.event.name }}</small>
+    </h1>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">
+                <i class="fa fa-fw fa-puzzle-piece"></i>
+                {% trans "Add-on Details" %}
+            </h3>
+        </div>
+        <div class="panel-body">
+            {% if addon.description %}
+                <p>{{ addon.description }}</p>
+            {% endif %}
+            <div class="row">
+                <div class="col-sm-6">
+                    <p>
+                        <strong>{% trans "Target Event:" %}</strong> {{ request.event.name }} (<code>{{ request.event.slug }}</code>)<br>
+                        <strong>{% trans "Capability / Feature:" %}</strong> <code>{{ addon.capability }}</code><br>
+                        {% if capability %}
+                            <strong>{% trans "Feature Name:" %}</strong> {{ capability.label }}<br>
+                        {% endif %}
+                        <strong>{% trans "Allowance per unit:" %}</strong> {{ addon.entitlement_value }}
+                        {% if capability.unit %} {{ capability.unit }}{% endif %}
+                    </p>
+                </div>
+                <div class="col-sm-6">
+                    <p>
+                        <strong>{% trans "Scope:" %}</strong>
+                        <span class="label label-info">{% trans "Event" %}</span><br>
+                        <strong>{% trans "Price:" %}</strong>
+                        {% if addon.price %}
+                            <span id="addon-pricing-display"
+                                  data-unit-price="{{ addon.price }}"
+                                  data-currency="{{ addon.currency }}"
+                                  data-pricing-mode="{{ addon.get_pricing_mode_display }}">
+                                <strong>{{ addon.price }} {{ addon.currency }}</strong> {% trans "per unit" %}
+                                <span class="text-muted">({{ addon.get_pricing_mode_display }})</span>
+                                <br>
+                                <span style="display: inline-block; margin-top: 5px;">
+                                    <strong>{% trans "Selected Quantity:" %}</strong> <span id="addon-selected-quantity">1</span><br>
+                                    <strong>{% trans "Total Cost:" %}</strong> <strong id="addon-calculated-total">{{ addon.price }} {{ addon.currency }}</strong>
+                                    <span class="text-muted">({% if addon.pricing_mode == "recurring" %}{% trans "Recurring fee" %}{% else %}{% trans "One-time payment" %}{% endif %})</span>
+                                </span>
+                            </span>
+                        {% else %}
+                            <span class="label label-success">{% trans "Free" %}</span>
+                        {% endif %}
+                    </p>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <form method="post" class="form-horizontal">
+        {% csrf_token %}
+        {% bootstrap_form form layout='horizontal' %}
+
+        <div class="form-group submit-group">
+            <button type="submit" class="btn btn-primary btn-save">
+                <i class="fa fa-check"></i> {% trans "Confirm & Enable for Event" %}
+            </button>
+            <a href="{% url 'plugins:eventyay_business:event.addons' organizer=request.organizer.slug event=request.event.slug %}" class="btn btn-default">
+                {% trans "Cancel" %}
+            </a>
+        </div>
+    </form>
+    <script type="module" src="{% static 'eventyay_business/addon_purchase.js' %}"></script>
+{% endblock %}

--- a/eventyay_business/templates/eventyay_business/event/addons.html
+++ b/eventyay_business/templates/eventyay_business/event/addons.html
@@ -1,0 +1,162 @@
+{% extends "pretixcontrol/event/base.html" %}
+{% load i18n %}
+{% load bootstrap3 %}
+
+{% block title %}{% trans "Add-ons & Modules" %} - {{ request.event.name }}{% endblock %}
+
+{% block content %}
+    <h1>
+        {% trans "Add-ons & Modules" %}
+        <small>{{ request.event.name }}</small>
+    </h1>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">
+                <i class="fa fa-fw fa-puzzle-piece"></i>
+                {% trans "Active Event Add-ons" %}
+            </h3>
+        </div>
+        <div class="panel-body">
+            <p class="text-muted" style="margin: 0;">
+                {% trans "Features, capability extensions, and modules currently active for this event." %}
+            </p>
+        </div>
+        {% if active_addons %}
+            <div class="table-responsive">
+                <table class="table table-hover table-striped" style="margin: 0;">
+                    <thead>
+                        <tr>
+                            <th>{% trans "Add-on Name" %}</th>
+                            <th>{% trans "Capability / Feature" %}</th>
+                            <th>{% trans "Allowance / Units" %}</th>
+                            <th>{% trans "Activated" %}</th>
+                            <th>{% trans "Expires / Duration" %}</th>
+                            <th class="text-right">{% trans "Status" %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for addon in active_addons %}
+                            <tr>
+                                <td>
+                                    <strong>{{ addon.addon.name }}</strong>
+                                    {% if addon.addon.description %}
+                                        <div class="help-block text-muted" style="margin: 2px 0 0; font-size: 12px;">
+                                            {{ addon.addon.description }}
+                                        </div>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <code>{{ addon.capability }}</code>
+                                </td>
+                                <td>
+                                    <strong>{{ addon.entitlement_value }}</strong>
+                                    {% if addon.quantity > 1 %}
+                                        <span class="text-muted">(x{{ addon.quantity }})</span>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    {{ addon.starts_at|date:"SHORT_DATETIME_FORMAT" }}
+                                </td>
+                                <td>
+                                    {% if addon.ends_at %}
+                                        {{ addon.ends_at|date:"SHORT_DATETIME_FORMAT" }}
+                                    {% else %}
+                                        <span class="text-muted">{% trans "No expiration" %}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="text-right">
+                                    {% if addon.status == "active" %}
+                                        <span class="label label-success">{% trans "Active" %}</span>
+                                    {% elif addon.status == "expired" %}
+                                        <span class="label label-default">{% trans "Expired" %}</span>
+                                    {% else %}
+                                        <span class="label label-warning">{{ addon.get_status_display }}</span>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <div class="panel-body text-muted">
+                <i class="fa fa-info-circle"></i> {% trans "No event-specific add-ons are currently active for this event." %}
+            </div>
+        {% endif %}
+    </div>
+
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">
+                <i class="fa fa-fw fa-shopping-bag"></i>
+                {% trans "Available Event Add-ons" %}
+            </h3>
+        </div>
+        <div class="panel-body">
+            <p class="text-muted" style="margin: 0;">
+                {% trans "Extend this event with optional event-level features and capabilities." %}
+            </p>
+        </div>
+        {% if available_addons %}
+            <div class="table-responsive">
+                <table class="table table-hover table-striped" style="margin: 0;">
+                    <thead>
+                        <tr>
+                            <th>{% trans "Add-on" %}</th>
+                            <th>{% trans "Feature / Allowance" %}</th>
+                            <th>{% trans "Price" %}</th>
+                            <th class="text-right">{% trans "Action" %}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for addon in available_addons %}
+                            <tr>
+                                <td>
+                                    <strong>{{ addon.name }}</strong>
+                                    {% if addon.description %}
+                                        <div class="help-block text-muted" style="margin: 2px 0 0; font-size: 12px;">
+                                            {{ addon.description }}
+                                        </div>
+                                    {% endif %}
+                                </td>
+                                <td>
+                                    <code>{{ addon.capability }}</code>
+                                    <br>
+                                    <small class="text-muted">
+                                        {% trans "Grants:" %} {{ addon.entitlement_value }}
+                                        {% if addon.quantity > 1 %}(x{{ addon.quantity }}){% endif %}
+                                    </small>
+                                </td>
+                                <td>
+                                    {% if addon.price %}
+                                        <strong>{{ addon.price }} {{ addon.currency }}</strong>
+                                        <br>
+                                        <small class="text-muted">{{ addon.get_pricing_mode_display }}</small>
+                                    {% else %}
+                                        <span class="label label-success">{% trans "Free" %}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="text-right">
+                                    {% if addon.is_active_for_event and addon.active_assignment.entitlement_value == "true" %}
+                                        <button class="btn btn-default btn-sm" disabled>
+                                            <i class="fa fa-check text-success"></i> {% trans "Active" %}
+                                        </button>
+                                    {% else %}
+                                        <a href="{% url 'plugins:eventyay_business:event.addon.purchase' organizer=request.organizer.slug event=request.event.slug pk=addon.pk %}" class="btn btn-primary btn-sm">
+                                            <i class="fa fa-plus"></i> {% trans "Enable for this Event" %}
+                                        </a>
+                                    {% endif %}
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <div class="panel-body text-muted">
+                {% trans "There are currently no additional event-level add-ons available for self-service purchase." %}
+            </div>
+        {% endif %}
+    </div>
+{% endblock %}

--- a/eventyay_business/urls.py
+++ b/eventyay_business/urls.py
@@ -119,4 +119,15 @@ urlpatterns = [
         views.OrganizerAddonPurchaseView.as_view(),
         name="organizer.addon.purchase",
     ),
+    # Event Dashboard URLs
+    path(
+        "control/event/<str:organizer>/<str:event>/business/addons/",
+        views.EventDashboardAddonsView.as_view(),
+        name="event.addons",
+    ),
+    path(
+        "control/event/<str:organizer>/<str:event>/business/addons/<int:pk>/purchase/",
+        views.EventDashboardAddonPurchaseView.as_view(),
+        name="event.addon.purchase",
+    ),
 ]

--- a/eventyay_business/views.py
+++ b/eventyay_business/views.py
@@ -16,6 +16,7 @@ from django.views.generic import (
 from eventyay.base.models import Event, Organizer
 from eventyay.control.permissions import (
     AdministratorPermissionRequiredMixin,
+    EventPermissionRequiredMixin,
     OrganizerPermissionRequiredMixin,
 )
 from eventyay.control.views.organizer_views.organizer_detail_view_mixin import (
@@ -26,6 +27,7 @@ from .capabilities import CapabilityValueType, get_all_capabilities, get_capabil
 from .forms import (
     AddonDefinitionForm,
     EventAddonForm,
+    EventAddonPurchaseForm,
     OrganizerAddonForm,
     OrganizerAddonPurchaseForm,
     SubscriptionAdminForm,
@@ -514,6 +516,120 @@ class OrganizerAddonPurchaseView(
         return redirect(
             "plugins:eventyay_business:organizer.plan",
             organizer=self.request.organizer.slug,
+        )
+
+
+class EventDashboardAddonsView(EventPermissionRequiredMixin, TemplateView):
+    permission = "can_change_event_settings"
+    template_name = "eventyay_business/event/addons.html"
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        event = self.request.event
+        current_time = now()
+
+        active_addons = list(
+            EventAddon.objects.filter(
+                event=event,
+                status=AddonStatus.ACTIVE,
+                starts_at__lte=current_time,
+            )
+            .exclude(ends_at__lt=current_time)
+            .order_by("-starts_at", "addon__name")
+        )
+        ctx["active_addons"] = active_addons
+
+        available_addons = list(
+            AddonDefinition.objects.filter(
+                active=True,
+                public=True,
+                assignment_scope=AddonAssignmentScope.EVENT,
+            ).order_by("name")
+        )
+
+        active_by_addon_id = {ea.addon_id: ea for ea in active_addons if ea.addon_id}
+        active_by_capability = {
+            ea.capability: ea for ea in active_addons if ea.capability
+        }
+
+        for addon in available_addons:
+            active_assignment = active_by_addon_id.get(
+                addon.id
+            ) or active_by_capability.get(addon.capability)
+            addon.active_assignment = active_assignment
+            addon.is_active_for_event = active_assignment is not None
+
+        ctx["available_addons"] = available_addons
+        return ctx
+
+
+class EventDashboardAddonPurchaseView(EventPermissionRequiredMixin, FormView):
+    permission = "can_change_event_settings"
+    template_name = "eventyay_business/event/addon_purchase.html"
+    form_class = EventAddonPurchaseForm
+
+    def get_addon(self):
+        return get_object_or_404(
+            AddonDefinition,
+            pk=self.kwargs["pk"],
+            active=True,
+            public=True,
+            assignment_scope=AddonAssignmentScope.EVENT,
+        )
+
+    def dispatch(self, request, *args, **kwargs):
+        self.addon = self.get_addon()
+        return super().dispatch(request, *args, **kwargs)
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["event"] = self.request.event
+        kwargs["addon"] = self.addon
+        return kwargs
+
+    def get_context_data(self, **kwargs):
+        ctx = super().get_context_data(**kwargs)
+        ctx["addon"] = self.addon
+        ctx["capability"] = get_capability(self.addon.capability)
+        return ctx
+
+    def form_valid(self, form):
+        cap = get_capability(self.addon.capability)
+        is_boolean = (cap and cap.value_type == CapabilityValueType.BOOLEAN) or (
+            self.addon.entitlement_value
+            and str(self.addon.entitlement_value).lower() in ("true", "1")
+        )
+
+        with transaction.atomic():
+            Event.objects.select_for_update().get(pk=self.request.event.pk)
+            if is_boolean:
+                if EventAddon.objects.filter(
+                    event=self.request.event,
+                    capability=self.addon.capability,
+                    status=AddonStatus.ACTIVE,
+                ).exists():
+                    messages.warning(
+                        self.request,
+                        _("This add-on is already active for %(event)s.")
+                        % {"event": self.request.event.name},
+                    )
+                    return redirect(
+                        "plugins:eventyay_business:event.addons",
+                        organizer=self.request.organizer.slug,
+                        event=self.request.event.slug,
+                    )
+
+            form.save()
+
+        messages.success(
+            self.request,
+            _("Add-on '%(name)s' has been successfully activated for %(event)s.")
+            % {"name": self.addon.name, "event": self.request.event.name},
+        )
+        return redirect(
+            "plugins:eventyay_business:event.addons",
+            organizer=self.request.organizer.slug,
+            event=self.request.event.slug,
         )
 
 

--- a/tests/test_event_addons.py
+++ b/tests/test_event_addons.py
@@ -1,0 +1,367 @@
+import pytest
+from decimal import Decimal
+from django.test import override_settings
+from django.urls import reverse
+from django.utils.timezone import now
+from eventyay.base.models import Event, Organizer, Team, User
+from eventyay.base.models.auth import StaffSession
+
+from eventyay_business.models import (
+    AddonAssignmentScope,
+    AddonDefinition,
+    AddonPricingMode,
+    AddonStatus,
+    EventAddon,
+)
+
+
+@pytest.fixture
+def business_admin_client(admin_client, admin_user):
+    session = admin_client.session
+    session.save()
+    StaffSession.objects.create(
+        user=admin_user,
+        session_key=session.session_key,
+        comment="test",
+    )
+    admin_user.is_staff = True
+    admin_user.save()
+    return admin_client
+
+
+@pytest.fixture
+def event_setup():
+    organizer = Organizer.objects.create(name="Acme Corp", slug="acme-corp")
+    event1 = Event.objects.create(
+        organizer=organizer,
+        name="Summit 1",
+        slug="summit-1",
+        date_from=now(),
+        live=True,
+    )
+    event2 = Event.objects.create(
+        organizer=organizer,
+        name="Summit 2",
+        slug="summit-2",
+        date_from=now(),
+        live=True,
+    )
+    return organizer, event1, event2
+
+
+@pytest.mark.django_db
+@override_settings(SITE_URL="https://testserver")
+def test_event_addons_list_view_shows_active_addons(business_admin_client, event_setup):
+    organizer, event1, event2 = event_setup
+
+    addon1 = AddonDefinition.objects.create(
+        name="Summit 1 Video Badge",
+        slug="summit-1-video",
+        capability="video.stream",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.EVENT,
+        active=True,
+        public=True,
+    )
+    addon2 = AddonDefinition.objects.create(
+        name="Summit 2 Exhibition",
+        slug="summit-2-exhibition",
+        capability="plugin.exhibition",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.EVENT,
+        active=True,
+        public=False,
+    )
+
+    EventAddon.objects.create(
+        event=event1,
+        addon=addon1,
+        capability=addon1.capability,
+        entitlement_value="true",
+        status=AddonStatus.ACTIVE,
+    )
+    EventAddon.objects.create(
+        event=event2,
+        addon=addon2,
+        capability=addon2.capability,
+        entitlement_value="true",
+        status=AddonStatus.ACTIVE,
+    )
+
+    url = reverse(
+        "plugins:eventyay_business:event.addons",
+        kwargs={"organizer": organizer.slug, "event": event1.slug},
+    )
+    resp = business_admin_client.get(url)
+    assert resp.status_code == 200
+    content = resp.content.decode()
+
+    # Active add-ons for event1 are visible
+    assert "Summit 1 Video Badge" in content
+    assert "video.stream" in content
+    assert "Active" in content
+
+    # Add-ons for event2 are not displayed in event1's dashboard
+    assert "Summit 2 Exhibition" not in content
+
+
+@pytest.mark.django_db
+@override_settings(SITE_URL="https://testserver")
+def test_event_addons_list_view_available_addons_filtering(
+    business_admin_client, event_setup
+):
+    organizer, event1, _ = event_setup
+
+    AddonDefinition.objects.create(
+        name="Public Event Feature",
+        slug="public-event-feature",
+        capability="plugin.public",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.EVENT,
+        price=Decimal("49.00"),
+        currency="USD",
+        pricing_mode=AddonPricingMode.ONE_TIME,
+        active=True,
+        public=True,
+    )
+    AddonDefinition.objects.create(
+        name="Private Event Feature",
+        slug="private-event-feature",
+        capability="plugin.private",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.EVENT,
+        active=True,
+        public=False,
+    )
+    AddonDefinition.objects.create(
+        name="Org Scoped Feature",
+        slug="org-scoped-feature",
+        capability="organizer.custom",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.ORGANIZER,
+        active=True,
+        public=True,
+    )
+
+    url = reverse(
+        "plugins:eventyay_business:event.addons",
+        kwargs={"organizer": organizer.slug, "event": event1.slug},
+    )
+    resp = business_admin_client.get(url)
+    assert resp.status_code == 200
+    content = resp.content.decode()
+
+    assert "Public Event Feature" in content
+    assert "Private Event Feature" not in content
+    assert "Org Scoped Feature" not in content
+    assert "Enable for this Event" in content
+
+
+@pytest.mark.django_db
+@override_settings(SITE_URL="https://testserver")
+def test_event_addons_list_marks_active_boolean_addon(
+    business_admin_client, event_setup
+):
+    organizer, event1, _ = event_setup
+
+    addon = AddonDefinition.objects.create(
+        name="Live Translation Stream",
+        slug="live-translation-stream",
+        capability="video.interpretation",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.EVENT,
+        active=True,
+        public=True,
+    )
+
+    EventAddon.objects.create(
+        event=event1,
+        addon=addon,
+        capability=addon.capability,
+        entitlement_value="true",
+        status=AddonStatus.ACTIVE,
+    )
+
+    url = reverse(
+        "plugins:eventyay_business:event.addons",
+        kwargs={"organizer": organizer.slug, "event": event1.slug},
+    )
+    resp = business_admin_client.get(url)
+    assert resp.status_code == 200
+    content = resp.content.decode()
+
+    assert "Live Translation Stream" in content
+    assert "Active" in content
+
+
+@pytest.mark.django_db
+@override_settings(SITE_URL="https://testserver")
+def test_event_addon_purchase_get_and_post(business_admin_client, event_setup):
+    organizer, event1, _ = event_setup
+
+    addon = AddonDefinition.objects.create(
+        name="Exhibitor Booths Pack",
+        slug="exhibitor-booths-pack",
+        capability="plugin.exhibition.booths",
+        entitlement_value="10",
+        quantity=5,
+        assignment_scope=AddonAssignmentScope.EVENT,
+        price=Decimal("150.00"),
+        currency="USD",
+        pricing_mode=AddonPricingMode.ONE_TIME,
+        active=True,
+        public=True,
+    )
+
+    purchase_url = reverse(
+        "plugins:eventyay_business:event.addon.purchase",
+        kwargs={"organizer": organizer.slug, "event": event1.slug, "pk": addon.pk},
+    )
+
+    # GET displays details and target event
+    resp_get = business_admin_client.get(purchase_url)
+    assert resp_get.status_code == 200
+    content = resp_get.content.decode()
+    assert "Exhibitor Booths Pack" in content
+    assert "Summit 1" in content
+
+    # POST purchase
+    resp_post = business_admin_client.post(purchase_url, {"quantity": 3}, follow=True)
+    assert resp_post.status_code == 200
+
+    assignment = EventAddon.objects.get(event=event1, addon=addon)
+    assert assignment.quantity == 3
+    assert assignment.capability == "plugin.exhibition.booths"
+    assert assignment.entitlement_value == "10"
+    assert assignment.price == Decimal("150.00")
+    assert assignment.currency == "USD"
+    assert assignment.status == AddonStatus.ACTIVE
+
+
+@pytest.mark.django_db
+@override_settings(SITE_URL="https://testserver")
+def test_event_addon_purchase_duplicate_boolean_rejected(
+    business_admin_client, event_setup
+):
+    organizer, event1, _ = event_setup
+
+    addon = AddonDefinition.objects.create(
+        name="Special Stream Module",
+        slug="special-stream-module",
+        capability="video.loungemesh",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.EVENT,
+        active=True,
+        public=True,
+    )
+
+    # Pre-existing active assignment
+    EventAddon.objects.create(
+        event=event1,
+        addon=addon,
+        capability=addon.capability,
+        entitlement_value="true",
+        status=AddonStatus.ACTIVE,
+    )
+
+    purchase_url = reverse(
+        "plugins:eventyay_business:event.addon.purchase",
+        kwargs={"organizer": organizer.slug, "event": event1.slug, "pk": addon.pk},
+    )
+    resp = business_admin_client.post(purchase_url, {"quantity": 1})
+    assert resp.status_code == 200
+    assert "already active" in resp.content.decode()
+
+
+@pytest.mark.django_db
+@override_settings(SITE_URL="https://testserver")
+def test_event_addon_purchase_private_or_inactive_returns_404(
+    business_admin_client, event_setup
+):
+    organizer, event1, _ = event_setup
+
+    private_addon = AddonDefinition.objects.create(
+        name="Private Addon",
+        slug="private-addon",
+        capability="video.stream",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.EVENT,
+        active=True,
+        public=False,
+    )
+    inactive_addon = AddonDefinition.objects.create(
+        name="Inactive Addon",
+        slug="inactive-addon",
+        capability="video.stream",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.EVENT,
+        active=False,
+        public=True,
+    )
+    org_addon = AddonDefinition.objects.create(
+        name="Org Addon",
+        slug="org-addon",
+        capability="video.stream",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.ORGANIZER,
+        active=True,
+        public=True,
+    )
+
+    for addon in [private_addon, inactive_addon, org_addon]:
+        purchase_url = reverse(
+            "plugins:eventyay_business:event.addon.purchase",
+            kwargs={"organizer": organizer.slug, "event": event1.slug, "pk": addon.pk},
+        )
+        resp = business_admin_client.get(purchase_url)
+        assert resp.status_code == 404
+
+
+@pytest.mark.django_db
+@override_settings(SITE_URL="https://testserver")
+def test_event_addons_permission_required(client, event_setup):
+    organizer, event1, _ = event_setup
+
+    addon = AddonDefinition.objects.create(
+        name="Event Module",
+        slug="event-module",
+        capability="video.stream",
+        entitlement_value="true",
+        assignment_scope=AddonAssignmentScope.EVENT,
+        active=True,
+        public=True,
+    )
+
+    list_url = reverse(
+        "plugins:eventyay_business:event.addons",
+        kwargs={"organizer": organizer.slug, "event": event1.slug},
+    )
+    purchase_url = reverse(
+        "plugins:eventyay_business:event.addon.purchase",
+        kwargs={"organizer": organizer.slug, "event": event1.slug, "pk": addon.pk},
+    )
+
+    # Anonymous redirected to login
+    resp_anon = client.get(list_url)
+    assert resp_anon.status_code == 302
+    assert "/login/" in resp_anon.url
+
+    # Authenticated user without event permission denied
+    unprivileged_user = User.objects.create_user(
+        "unprivileged_event@example.com", "dummy"
+    )
+    team = Team.objects.create(
+        organizer=organizer,
+        name="No Settings Team",
+        all_events=True,
+        can_view_orders=True,
+        can_change_event_settings=False,
+    )
+    team.members.add(unprivileged_user)
+    client.force_login(unprivileged_user)
+
+    resp_denied = client.get(list_url)
+    assert resp_denied.status_code == 403
+
+    resp_purchase_denied = client.get(purchase_url)
+    assert resp_purchase_denied.status_code == 403

--- a/tests/test_nav.py
+++ b/tests/test_nav.py
@@ -2,7 +2,10 @@ from django.test import RequestFactory
 from django.urls import ResolverMatch
 from unittest.mock import Mock
 
-from eventyay_business.signals import business_tiers_nav
+from eventyay_business.signals import (
+    business_event_addons_nav,
+    business_tiers_nav,
+)
 
 
 def test_business_tiers_nav_anonymous():
@@ -139,3 +142,84 @@ def test_business_tiers_nav_staff_on_addons_list():
     assert items[0]["active"] is False
     assert items[1]["active"] is False
     assert items[2]["active"] is True
+
+
+def test_business_event_addons_nav_anonymous():
+    factory = RequestFactory()
+    request = factory.get("/control/event/test-org/test-event/settings/")
+    request.user = Mock(is_authenticated=False)
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs={"organizer": "test-org", "event": "test-event"},
+        url_name="event.settings",
+        app_names=["pretixcontrol"],
+        namespaces=["control"],
+    )
+    items = business_event_addons_nav(sender=None, request=request)
+    assert items == []
+
+
+def test_business_event_addons_nav_without_permission():
+    factory = RequestFactory()
+    request = factory.get("/control/event/test-org/test-event/settings/")
+    user = Mock(is_authenticated=True)
+    user.has_event_permission.return_value = False
+    request.user = user
+    request.organizer = Mock(slug="test-org")
+    request.event = Mock(slug="test-event")
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs={"organizer": "test-org", "event": "test-event"},
+        url_name="event.settings",
+        app_names=["pretixcontrol"],
+        namespaces=["control"],
+    )
+    items = business_event_addons_nav(sender=request.event, request=request)
+    assert items == []
+
+
+def test_business_event_addons_nav_with_permission():
+    factory = RequestFactory()
+    request = factory.get("/control/event/test-org/test-event/settings/")
+    user = Mock(is_authenticated=True)
+    user.has_event_permission.return_value = True
+    request.user = user
+    request.organizer = Mock(slug="test-org")
+    request.event = Mock(slug="test-event")
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs={"organizer": "test-org", "event": "test-event"},
+        url_name="event.settings",
+        app_names=["pretixcontrol"],
+        namespaces=["control"],
+    )
+    items = business_event_addons_nav(sender=request.event, request=request)
+    assert len(items) == 1
+    assert str(items[0]["label"]) == "Add-ons & Modules"
+    assert items[0]["active"] is False
+    assert "test-org" in items[0]["url"]
+    assert "test-event" in items[0]["url"]
+
+
+def test_business_event_addons_nav_active():
+    factory = RequestFactory()
+    request = factory.get("/control/event/test-org/test-event/business/addons/")
+    user = Mock(is_authenticated=True)
+    user.has_event_permission.return_value = True
+    request.user = user
+    request.organizer = Mock(slug="test-org")
+    request.event = Mock(slug="test-event")
+    request.resolver_match = ResolverMatch(
+        func=lambda r: None,
+        args=(),
+        kwargs={"organizer": "test-org", "event": "test-event"},
+        url_name="event.addons",
+        app_names=["plugins:eventyay_business"],
+        namespaces=["plugins:eventyay_business"],
+    )
+    items = business_event_addons_nav(sender=request.event, request=request)
+    assert len(items) == 1
+    assert items[0]["active"] is True


### PR DESCRIPTION

<img width="5088" height="3364" alt="image" src="https://github.com/user-attachments/assets/ae54ddd5-0bb8-4c3f-b991-7ade9a1e756f" />




Closes #71

### Summary of Changes

1. **Event Dashboard Navigation**:
   - Registered `business_event_addons_nav` signal receiver on `nav_event_settings`.
   - Surfaces **"Add-ons & Modules"** under event settings navigation for users with `can_change_event_settings` permission.

2. **Event Add-ons Dashboard View**:
   - Created `EventDashboardAddonsView` at route `control/event/<organizer>/<event>/business/addons/`.
   - Displays all active `EventAddon` records for the specific event, with capability identifiers, snapshot allowances, activation dates, expiration dates, and status badges.
   - Surfaces available public event-scoped add-on definitions in an **"Available Event Add-ons"** marketplace section, showing capability details, pricing, and an action to enable the add-on for the current event (with active boolean add-ons disabled as "Active").

3. **Event-scoped Add-on Acquisition**:
   - Created `EventAddonPurchaseForm` and `EventDashboardAddonPurchaseView` at route `control/event/<organizer>/<event>/business/addons/<pk>/purchase/`.
   - Pre-selects and binds target event directly from URL context.
   - Enforces duplicate boolean capability protection under `transaction.atomic()` and `Event.objects.select_for_update()`.
   - Integrates dynamic pricing recalculation using the external ES module `addon_purchase.js`.

4. **Testing**:
   - Added navigation unit tests in `tests/test_nav.py` for anonymous, unauthorized, authorized, and active route states.
   - Added comprehensive event add-ons test suite in `tests/test_event_addons.py` covering event scoping isolation, catalog filtering, boolean duplicate protection, 404 responses for inactive/private/organizer definitions, and permission enforcement.
   - Verified that all **86 unit tests** in `eventyay-business` pass cleanly in Docker.
   - Formatted and lint-clean with `black`, `isort`, and `flake8`.

## Summary by Sourcery

Enable authorized event staff to browse, purchase, and manage event-level add-ons directly from the event dashboard.

New Features:
- Add event dashboard navigation for managing event-scoped add-ons and modules.
- Provide event-scoped add-on discovery, details, pricing, and activation workflows.
- Display active event add-ons with their capabilities, allowances, dates, and statuses.

Bug Fixes:
- Prevent duplicate activation of boolean add-on capabilities for the same event, including concurrent purchases.

Enhancements:
- Restrict event add-on availability and management to active, public event-scoped definitions and authorized event staff.

Tests:
- Add coverage for event scoping, catalog filtering, permissions, invalid definitions, purchases, duplicate boolean add-ons, and navigation states.